### PR TITLE
✨ feat: 공통 API 응답 규격 및 전역 예외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/kr/co/isajjim/global/common/ApiResponse.java
+++ b/src/main/java/kr/co/isajjim/global/common/ApiResponse.java
@@ -1,0 +1,63 @@
+package kr.co.isajjim.global.common;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApiResponse<T>(
+        String code,
+        String message,
+        List<FieldErrorDetail> details,
+        T data
+) {
+
+    public static <T> ApiResponse<T> ofSuccess(final BaseResponseCode responseCode) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofSuccess(final BaseResponseCode responseCode, T data) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofFail(final BaseResponseCode responseCode) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofFail(final BaseResponseCode responseCode, final List<FieldError> fieldErrors) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .details(FieldErrorDetail.of(fieldErrors))
+                .build();
+    }
+
+    private record FieldErrorDetail(
+            String field,
+            String message
+    ) {
+
+        private static FieldErrorDetail of(final FieldError fieldError) {
+            return new FieldErrorDetail(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        private static List<FieldErrorDetail> of(final List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(FieldErrorDetail::of)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/kr/co/isajjim/global/common/BaseResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/BaseResponseCode.java
@@ -1,0 +1,10 @@
+package kr.co.isajjim.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseResponseCode {
+
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/kr/co/isajjim/global/common/CommonResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/CommonResponseCode.java
@@ -1,0 +1,36 @@
+package kr.co.isajjim.global.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonResponseCode implements BaseResponseCode {
+
+    // 2xx Success
+    OK(HttpStatus.OK, "OK", "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "CREATED", "리소스가 성공적으로 생성되었습니다."),
+
+    // 400 Bad Request
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-001", "잘못된 요청입니다."),
+    INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "COMMON-002", "올바르지 않은 요청 형식입니다."),
+    DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "COMMON-003", "데이터 무결성 제약 조건을 위반하였습니다."),
+
+    // 403 Forbidden
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-004", "요청 리소스에 대한 접근 권한이 없습니다."),
+
+    // 404 Not Found
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-005", "요청 리소스를 찾을 수 없습니다."),
+
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-006", "요청 메소드를 지원하지 않습니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-007", "서버 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/co/isajjim/global/exception/BaseException.java
+++ b/src/main/java/kr/co/isajjim/global/exception/BaseException.java
@@ -1,0 +1,15 @@
+package kr.co.isajjim.global.exception;
+
+import kr.co.isajjim.global.common.BaseResponseCode;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final BaseResponseCode responseCode;
+
+    public BaseException(BaseResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+    }
+}

--- a/src/main/java/kr/co/isajjim/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/isajjim/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,79 @@
+package kr.co.isajjim.global.exception;
+
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.BaseResponseCode;
+import kr.co.isajjim.global.common.CommonResponseCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
+        BaseResponseCode responseCode = e.getResponseCode();
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.DATA_INTEGRITY_VIOLATION;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("AccessDeniedException: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.FORBIDDEN;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Exception: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(NoResourceFoundException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        BaseResponseCode responseCode = CommonResponseCode.NOT_FOUND;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("HttpRequestMethodNotSupportedException: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.METHOD_NOT_ALLOWED;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("MethodArgumentNotValidException: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.INVALID_METHOD_ARGUMENT;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode, e.getBindingResult().getFieldErrors()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("JSON Parse Error: ", e);
+        BaseResponseCode responseCode = CommonResponseCode.BAD_REQUEST;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+}


### PR DESCRIPTION
## 🚀 개요

- API 응답에 필요한 공통 규격 및 전역 예외 처리를 구현하였습니다.

## ✨ 작업 내용

- API 응답 포맷 ApiResponse를 정의하였습니다.
  - 스프링에는 ResponseEntity라는 응답 객체가 이미 존재하지만 응답 형식을 표준화하고 부가적인 정보를 담아 프론트엔드 단에서 구체적인 응답을 확인할 수 있도록 ApiResponse라는 공통 응답을 생성해주었습니다.
  - code는 커스텀 응답 코드(후술), message는 응답 메시지, details에는 필드 에러 정보, data에는 API 응답 데이터가 들어갑니다.

```java
  public record ApiResponse<T>(
		String code,
		String message,
		List<FieldErrorDetail> details,
		T data
)
```
<img width="260" height="200" alt="image" src="https://github.com/user-attachments/assets/d6eb0a45-8c44-41c4-a087-b20129e56025" />


- 응답 코드 포맷 BaseResponseCode 인터페이스를 정의하였습니다.
  -  표준 응답은 CommonResponseCode 구현체로 구현하였습니다.
```java
public interface BaseResponseCode {

    HttpStatus getStatus();
    String getCode();
    String getMessage();
}
```


- BaseResponseCode를 상속한 표준 응답 클래스입니다.
- code를 COMMON-XXX, DOMAIN-XXX 로 커스텀한 이유 : [블로그 게시글](https://ctce7226.tistory.com/8)
```java
public enum CommonResponseCode implements BaseResponseCode {

    // 2xx Success
    OK(HttpStatus.OK, "OK", "요청이 성공적으로 처리되었습니다."),
    CREATED(HttpStatus.CREATED, "CREATED", "리소스가 성공적으로 생성되었습니다."),

    // 400 Bad Request
    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-001", "잘못된 요청입니다."),
    ;
}
```

- BaseException : 프로젝트에서 사용할 예외입니다.
```java
public class BaseException extends RuntimeException {
    private final BaseResponseCode responseCode;

    public BaseException(BaseResponseCode responseCode) {
        super(responseCode.getMessage());
        this.responseCode = responseCode;
    }
}
```
- 사용 예시
```java
throw new BaseException(CommonResponseCode.NOT_FOUND);
```

- GlobalExceptionHandler : 예외를 공통적으로 처리하기 위한 핸들러입니다.
  - 컨트롤러단이 아닌 Servlet단(스프링 내부)에서 발생하는 예외 또한 GlobalExceptionHandler 에서 공통으로 처리해주기 위해 ResponseEntityExceptionHandler 를 상속하였습니다.