### PR TITLE
🔧 chore: application.yml 템플릿화 및 .env 도입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEV_SWAGGER_URL=https://dev.isajjim.co.kr

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,8 +41,6 @@ jobs:
         run: |
           mkdir -p configs/
           
-          echo "${{ secrets.APPLICATION_SECRET }}" | base64 --decode > configs/application.yml
-          echo "${{ secrets.APPLICATION_SECRET_PROFILE }}" | base64 --decode > configs/application-${{ vars.SPRING_PROFILE }}.yml
           echo "${{ secrets.ENV }}" | base64 --decode > configs/.env
           echo "" >> configs/.env
           echo "SPRING_PROFILE=${{ vars.SPRING_PROFILE }}" >> configs/.env

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     // Database
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "8080:8080"
     networks:
       - backend
+    env_file:
+      - .env
     volumes:
       - ./configs:/configs
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   spring:
-    image: ghcr.io/fittruck/isajjim-backend:develop
+    image: ghcr.io/fittruck/isajjim-backend:dev
     container_name: spring
     ports:
       - "8080:8080"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,10 @@
+# application-dev.yml
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+swagger:
+  server-url: ${DEV_SWAGGER_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,11 @@
+# application-local.yml
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/isajjim
+#   url: jdbc:h2:mem:isajjim
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+swagger:
+  server-url: http://localhost:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,10 @@
+# application.yml
 spring:
   application:
     name: isajjim
+  profiles:
+    active: local
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
## 🚀 개요

- 기존의 application.yml은 API 키 등 민감한 정보를 직접 포함하고 있어 보안상의 이유로 GitHub에 공유할 수 없었습니다. 이로 인해 프로젝트를 새로 클론한 외부 개발자가 즉시 서버를 실행하거나 개발에 참여하는 데 큰 진입장벽이 있었습니다.
- 따라서 application.yml을 템플릿화 하여 외부 사용자가 전체적인 설정 구조를 파악할 수 있게 하고, 민감 정보는 .env 파일에 포함하여 보안을 강화하였습니다.

## ✨ 작업 내용

1. 프로젝트 루트에 .env 파일 생성, .gitignore에 추가

```yaml
# .env
DEV_SWAGGER_URL=http://api.isajjim.kro.kr:8080
```

2. .env를 어떻게 설정할 지 알 수 있도록 예시 파일 추가
```yaml
# .env.example
DEV_SWAGGER_URL=https://dev.isajjim.co.kr
```

3. application.yml 수정 예시 (.env에서 값 주입)

```yaml
swagger:
  server-url: ${DEV_SWAGGER_URL}
```

4. 인텔리제이에서 .env 파일을 주입받는 법
- File -> Settings-> Plugins -> `Envfile` 플러그인 설치
- Run/Debug Configuration → Enable EnvFile 체크, + 눌러서 .env 파일 선택

5. CD 수정
- 이미 .env 파일을 서버로 보내주고 있음
- 기존 Github secret에서 application.yml을 보내던 코드를 삭제, Github secret에서도 삭제

6. Docker-compose에서 Spring 컨테이너가 .env 파일을 바라보도록 추가
```yaml
env_file:
  - .env
```

7. 편해진 점
- application.yml 버전관리가 가능해졌습니다.
- PORT, HOST 등은 스프링부트 내부에서 사용하는 것이 아닌, 배포에 필요한 값들이므로 Github secret에 유지하였습니다.