### PR TITLE
🐛 fix: DB 생성 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "8080:8080"
     networks:
       - backend
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file:
       - .env
     volumes:

--- a/src/main/java/kr/co/isajjim/domains/furniture/domain/constant/FurnitureType.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/domain/constant/FurnitureType.java
@@ -1,4 +1,5 @@
 package kr.co.isajjim.domains.furniture.domain.constant;
 
 public enum FurnitureType {
+    QUEEN
 }


### PR DESCRIPTION
## 🚀 개요

- 원격 mysql에서 DB가 생성되지 않는 오류를 해결하였습니다.

## ✨ 작업 내용

- FurnitureType Enum의 값이 정의되어 있지 않아 테이블이 생성되지 않는 오류를 수정하였습니다.
- Docker의 Spring 컨테이너에서 myslq로 연결되지 않는 문제를 수정하였습니다.

## 🔧 앞으로의 과제

- 추후 동일 인스턴스에 데이터베이스를 두지 않고, 별도 인스턴스를 생성하여 private로 연결할 예정임.