### PR TITLE
✨ feat: 이미지 AI 처리 구현

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -6,11 +6,13 @@ import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
-import kr.co.isajjim.domains.image.application.mapper.ImageMapper;
-import kr.co.isajjim.domains.image.persistence.entity.Image;
+import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.infra.ai.domain.service.AIService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -18,18 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class EstimateUseCase {
 
     private final EstimateService estimateService;
+    private final AIService aiService;
 
     @Transactional
-    public Long createEstimate(EstimateRequest request) {
-        Estimate estimate = EstimateMapper.toEstimate();
-        request.imageUrls()
-                .forEach(imageUrl -> {
-                            Image image = ImageMapper.toImage(imageUrl);
-                            estimate.addImage(image);
-                        }
-                );
+    public Long createAndAnalyze(EstimateRequest request) {
+        Long estimateId = estimateService.createEstimate(request);
 
-        return estimateService.createEstimate(estimate);
+        List<ImageAnalysisDto> imageDtos = estimateService.getImageDtos(estimateId);
+        aiService.analyzeFurniture(estimateId, imageDtos);
+
+        return estimateId;
     }
 
     public EstimateDetailResponse getDetailEstimates(Long estimateId) {

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -1,25 +1,44 @@
 package kr.co.isajjim.domains.estimate.domain.service;
 
+import kr.co.isajjim.domains.estimate.application.mapper.EstimateMapper;
+import kr.co.isajjim.domains.estimate.application.request.EstimateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.estimate.persistence.repository.EstimateRepository;
+import kr.co.isajjim.domains.image.application.mapper.ImageMapper;
+import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
+import kr.co.isajjim.domains.image.domain.service.ImageService;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class EstimateService {
 
     private final EstimateRepository estimateRepository;
+    private final ImageService imageService;
 
     public Estimate getEstimateById(Long estimateId) {
         return getOrThrow(estimateId);
     }
 
-    public Long createEstimate(Estimate estimate) {
+    public Long createEstimate(EstimateRequest request) {
+        Estimate estimate = EstimateMapper.toEstimate();
+        request.imageUrls().forEach(url -> estimate.addImage(ImageMapper.toImage(url)));
+
         return estimateRepository.save(estimate).getId();
+    }
+
+    public List<ImageAnalysisDto> getImageDtos(Long estimateId) {
+        return imageService.getAllByEstimateId(estimateId).stream()
+                .map(img -> new ImageAnalysisDto(img.getId(), img.getImageUrl()))
+                .toList();
     }
 
     public void updateDefaultInfo(Estimate estimate, EstimateUpdateRequest request) {
@@ -34,6 +53,12 @@ public class EstimateService {
                 request.groundStair(),
                 request.parking()
         );
+    }
+
+    @Transactional
+    public void updateAIStatus(Long estimateId, AIStatus status) {
+        Estimate estimate = getOrThrow(estimateId);
+        estimate.updateAIStatus(status);
     }
 
     /* HELPER METHOD */

--- a/src/main/java/kr/co/isajjim/domains/estimate/persistence/entity/Estimate.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/persistence/entity/Estimate.java
@@ -114,4 +114,8 @@ public class Estimate extends BaseEntity {
         this.groundStair = (groundStair != null) ? groundStair : this.groundStair;
         this.parking = (parking != null) ? parking : this.parking;
     }
+
+    public void updateAIStatus(AIStatus aiStatus) {
+        this.aiStatus = aiStatus;
+    }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -25,7 +25,7 @@ public class EstimateController implements EstimateApi {
     public ResponseEntity<ApiResponse<EstimateResponse>> createEstimate(
             @RequestBody @Valid EstimateRequest request
     ) {
-        Long savedId = estimateUseCase.createEstimate(request);
+        Long savedId = estimateUseCase.createAndAnalyze(request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, EstimateResponse.from(savedId)));
     }
 

--- a/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
@@ -2,8 +2,23 @@ package kr.co.isajjim.domains.furniture.application.mapper;
 
 import kr.co.isajjim.domains.furniture.FurnitureResponse;
 import kr.co.isajjim.domains.furniture.persistence.entity.Furniture;
+import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 
 public class FurnitureMapper {
+    public static Furniture toFurniture(
+            AIAnalysisResponse.FurnitureInfo info
+    ) {
+        return Furniture.builder()
+                .label(info.label())
+                .width(info.width())
+                .depth(info.depth())
+                .height(info.height())
+                .ratioWidth(info.ratio().w())
+                .ratioDepth(info.ratio().d())
+                .ratioHeight(info.ratio().h())
+                .build();
+    }
+
     public static FurnitureResponse fromFurniture(
             Furniture furniture
     ) {

--- a/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
@@ -16,6 +16,7 @@ public class FurnitureMapper {
                 .ratioWidth(info.ratio().w())
                 .ratioDepth(info.ratio().d())
                 .ratioHeight(info.ratio().h())
+                .count(1)
                 .build();
     }
 

--- a/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
@@ -1,0 +1,42 @@
+package kr.co.isajjim.domains.furniture.domain.service;
+
+import kr.co.isajjim.domains.furniture.application.mapper.FurnitureMapper;
+import kr.co.isajjim.domains.furniture.persistence.entity.Furniture;
+import kr.co.isajjim.domains.furniture.persistence.repository.FurnitureRepository;
+import kr.co.isajjim.domains.image.domain.service.ImageService;
+import kr.co.isajjim.domains.image.persistence.entity.Image;
+import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FurnitureService {
+
+    private final FurnitureRepository furnitureRepository;
+    private final ImageService imageService;
+
+    @Transactional
+    public void saveFurnitureList(List<AIAnalysisResponse.ImageResult> imageResults) {
+        for (AIAnalysisResponse.ImageResult result : imageResults) {
+            saveFurniturePerImage(result);
+        }
+    }
+
+    private void saveFurniturePerImage(AIAnalysisResponse.ImageResult result) {
+        Image image = imageService.getImageById(result.imageId());
+
+        List<Furniture> furnitureList = result.objects().stream()
+                .map(info -> {
+                    Furniture furniture = FurnitureMapper.toFurniture(info);
+                    furniture.setImage(image);
+                    return furniture;
+                })
+                .toList();
+
+        furnitureRepository.saveAll(furnitureList);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
@@ -30,19 +30,17 @@ public class Furniture {
     @Enumerated(EnumType.STRING)
     private FurnitureType type;
 
-    private Integer width;
+    private Double width;
 
-    private Integer height;
+    private Double height;
 
-    private Integer depth;
+    private Double depth;
 
-    private Integer volume;
+    private Double ratioWidth;
 
-    private Integer ratioWidth;
+    private Double ratioHeight;
 
-    private Integer ratioHeight;
-
-    private Integer ratioDepth;
+    private Double ratioDepth;
 
     private Integer count;
 
@@ -50,13 +48,12 @@ public class Furniture {
     private Furniture(
         FurnitureLabel label,
         FurnitureType type,
-        Integer width,
-        Integer height,
-        Integer depth,
-        Integer volume,
-        Integer ratioWidth,
-        Integer ratioHeight,
-        Integer ratioDepth,
+        Double width,
+        Double height,
+        Double depth,
+        Double ratioWidth,
+        Double ratioHeight,
+        Double ratioDepth,
         Integer count
     ) {
         this.label = label;
@@ -64,7 +61,6 @@ public class Furniture {
         this.width = width;
         this.height = height;
         this.depth = depth;
-        this.volume = volume;
         this.ratioWidth = ratioWidth;
         this.ratioHeight = ratioHeight;
         this.ratioDepth = ratioDepth;

--- a/src/main/java/kr/co/isajjim/domains/image/application/response/ImageAnalysisDto.java
+++ b/src/main/java/kr/co/isajjim/domains/image/application/response/ImageAnalysisDto.java
@@ -1,0 +1,7 @@
+package kr.co.isajjim.domains.image.application.response;
+
+public record ImageAnalysisDto(
+        Long id,
+        String url
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/image/domain/service/ImageService.java
+++ b/src/main/java/kr/co/isajjim/domains/image/domain/service/ImageService.java
@@ -2,8 +2,12 @@ package kr.co.isajjim.domains.image.domain.service;
 
 import kr.co.isajjim.domains.image.persistence.entity.Image;
 import kr.co.isajjim.domains.image.persistence.repository.ImageRepository;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -11,11 +15,25 @@ public class ImageService {
 
     private final ImageRepository imageRepository;
 
+    public Image getImageById(Long imageId) {
+        return getOrThrow(imageId);
+    }
+
     public Long createImage(Image image) {
         return imageRepository.save(image).getId();
     }
 
     public Image saveImage(Image image) {
         return imageRepository.save(image);
+    }
+
+    /* HELPER METHOD */
+    private Image getOrThrow(Long id) {
+        return imageRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND));
+    }
+
+    public List<Image> getAllByEstimateId(Long estimateId) {
+        return imageRepository.findAllByEstimateId(estimateId);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/image/persistence/entity/Image.java
+++ b/src/main/java/kr/co/isajjim/domains/image/persistence/entity/Image.java
@@ -1,7 +1,6 @@
 package kr.co.isajjim.domains.image.persistence.entity;
 
 import jakarta.persistence.*;
-import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.furniture.persistence.entity.Furniture;
 import kr.co.isajjim.global.base.entity.BaseEntity;
@@ -26,9 +25,6 @@ public class Image extends BaseEntity {
 
     private String imageUrl;
 
-    @Enumerated(EnumType.STRING)
-    private AIStatus status;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "estimate_id")
     private Estimate estimate;
@@ -41,7 +37,6 @@ public class Image extends BaseEntity {
             String imageUrl
     ) {
         this.imageUrl = imageUrl;
-        this.status = AIStatus.PENDING;
     }
 
     public void setEstimate(Estimate estimate) {

--- a/src/main/java/kr/co/isajjim/domains/image/persistence/repository/ImageRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/image/persistence/repository/ImageRepository.java
@@ -3,5 +3,8 @@ package kr.co.isajjim.domains.image.persistence.repository;
 import kr.co.isajjim.domains.image.persistence.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findAllByEstimateId(Long estimateId);
 }

--- a/src/main/java/kr/co/isajjim/global/config/async/AsyncConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/async/AsyncConfig.java
@@ -1,0 +1,28 @@
+package kr.co.isajjim.global.config.async;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(60);
+        executor.setQueueCapacity(10000);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        executor.setRejectedExecutionHandler((r, exec) -> {
+            throw new IllegalArgumentException("더 이상 요청을 처리할 수 없습니다.");
+        });
+        return executor;
+    }
+}

--- a/src/main/java/kr/co/isajjim/global/config/restclient/RestClientConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/restclient/RestClientConfig.java
@@ -1,0 +1,35 @@
+package kr.co.isajjim.global.config.restclient;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    @Value("${rest-client.connect-timeout}")
+    private long CONNECT_TIMEOUT;
+
+    @Value("${rest-client.read-timeout}")
+    private long READ_TIMEOUT;
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder()
+                .requestFactory(customRequestFactory())
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    private ClientHttpRequestFactory customRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT));
+        factory.setReadTimeout(Duration.ofSeconds(READ_TIMEOUT));
+        return factory;
+    }
+}

--- a/src/main/java/kr/co/isajjim/global/config/web/WebConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/web/WebConfig.java
@@ -1,0 +1,17 @@
+package kr.co.isajjim.global.config.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/ai/application/dto/AIAnalysisResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/application/dto/AIAnalysisResponse.java
@@ -1,0 +1,33 @@
+package kr.co.isajjim.infra.ai.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
+
+import java.util.List;
+
+public record AIAnalysisResponse(
+        List<ImageResult> results
+) {
+    public record ImageResult(
+            @JsonProperty("image_id")
+            Long imageId,
+            List<FurnitureInfo> objects
+    ) {
+    }
+
+    public record FurnitureInfo(
+            FurnitureLabel label,
+            Double width,
+            Double depth,
+            Double height,
+            FurnitureRatio ratio
+    ) {
+    }
+
+    public record FurnitureRatio(
+            Double w,
+            Double d,
+            Double h
+    ) {
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
@@ -1,0 +1,79 @@
+package kr.co.isajjim.infra.ai.domain.service;
+
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
+import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
+import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
+import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AIService {
+
+    @Value("${infra.ai.base-url}")
+    private String url;
+
+    private final RestClient restClient;
+    private final FurnitureService furnitureService;
+    private final EstimateService estimateService;
+
+    @Async
+    public void analyzeFurniture(Long estimateId, List<ImageAnalysisDto> images) {
+        try {
+            estimateService.updateAIStatus(estimateId, AIStatus.PROCESSING);
+            /*
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("image_urls", images);
+
+            AIAnalysisResponse response = restClient.post()
+                    .uri(url + "/analyze-furniture")
+                    .body(requestBody)
+                    .retrieve()
+                    .body(AIAnalysisResponse.class);
+            */
+
+            // Mock Data 이용
+            AIAnalysisResponse response = getMockData(images.get(0).id(), images.get(1).id());
+
+            furnitureService.saveFurnitureList(response.results());
+            estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
+        } catch (Exception e) {
+            log.error("AI 분석 중 오류 발생: {}", e.getMessage());
+            estimateService.updateAIStatus(estimateId, AIStatus.FAILED);
+            throw new BaseException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private AIAnalysisResponse getMockData(Long imageId1, Long imageId2) {
+        AIAnalysisResponse.ImageResult image1 = new AIAnalysisResponse.ImageResult(
+                imageId1,
+                List.of(
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.BED, 30.5, 20.0, 15.2, new AIAnalysisResponse.FurnitureRatio(0.2, 0.3, 0.4)),
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 210.0, 90.0, 85.0, new AIAnalysisResponse.FurnitureRatio(0.2, 0.3, 0.4))
+                )
+        );
+
+        AIAnalysisResponse.ImageResult image2 = new AIAnalysisResponse.ImageResult(
+                imageId2,
+                List.of(
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 45.0, 50.0, 90.0, new AIAnalysisResponse.FurnitureRatio(0.2, 0.3, 0.4))
+                )
+        );
+
+        return new AIAnalysisResponse(
+                List.of(image1, image2)
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
 rest-client:
   connect-timeout: 5
   read-timeout: 30
+
+infra:
+  ai:
+    base-url: ${AI_BASE_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: update
+
+rest-client:
+  connect-timeout: 5
+  read-timeout: 30


### PR DESCRIPTION
## 🚀 개요

- 업로드 받은 이미지URL을 AI 서버에 요청한 후, 이미지 엔티티의 가구 목록에 추가하는 로직을 구현하였습니다.

## ✨ 작업 내용

- POST `/api/v1/estimates` 호출 시 업로드된 이미지 URL 목록을 AI 서버로 호출(현재 Mock 데이터) -> 응답 받은 가구 목록을 이미지 엔티티에 추가, AI 처리 완료 후 응답으로 반환

## 🔧 앞으로의 과제

- 견적서 GET API 추가
- 가구 수량 조정 및 실시간 견적 조회 API 구현

## 💡 기술적 사항

- 견적서 생성 시 estimateId를 먼저 반환한 후, AI 처리 요청은 비동기로 진행