### PR TITLE
✨ feat: 가구 수량 조정 및 실시간 견적 조회 API 구현

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateMapper.java
@@ -1,6 +1,7 @@
 package kr.co.isajjim.domains.estimate.application.mapper;
 
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemResponse;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
@@ -40,5 +41,11 @@ public class EstimateMapper {
                 .category(estimateItem.getCategory())
                 .itemType(estimateItem.getType())
                 .build();
+    }
+
+    public static EstimateItemListResponse toEstimateItemListResponse(
+            List<EstimateItemResponse> items
+    ) {
+        return EstimateItemListResponse.toEstimateItemListResponse(items);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/request/EstimateItemUpdateRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/request/EstimateItemUpdateRequest.java
@@ -1,6 +1,8 @@
 package kr.co.isajjim.domains.estimate.application.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record EstimateItemUpdateRequest(
@@ -16,7 +18,8 @@ public record EstimateItemUpdateRequest(
                 description = "가구 수량",
                 example = "1"
         )
-        @NotNull
+        @Min(0)
+        @Max(100)
         Integer quantity
 ) {
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/request/EstimateItemUpdateRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/request/EstimateItemUpdateRequest.java
@@ -1,0 +1,22 @@
+package kr.co.isajjim.domains.estimate.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record EstimateItemUpdateRequest(
+
+        @Schema(
+                description = "가구 ID",
+                example = "1"
+        )
+        @NotNull
+        Long furnitureId,
+
+        @Schema(
+                description = "가구 수량",
+                example = "1"
+        )
+        @NotNull
+        Integer quantity
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/response/EstimateItemListResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/response/EstimateItemListResponse.java
@@ -1,0 +1,18 @@
+package kr.co.isajjim.domains.estimate.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record EstimateItemListResponse(
+        @Schema(description = "견적 목록")
+        List<EstimateItemResponse> items
+) {
+    public static EstimateItemListResponse toEstimateItemListResponse(List<EstimateItemResponse> items) {
+        return EstimateItemListResponse.builder()
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -1,11 +1,16 @@
 package kr.co.isajjim.domains.estimate.application.usecase;
 
 import kr.co.isajjim.domains.estimate.application.mapper.EstimateMapper;
+import kr.co.isajjim.domains.estimate.application.request.EstimateItemUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateItemResponse;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
+import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
+import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.annotation.UseCase;
 import kr.co.isajjim.infra.ai.domain.service.AIService;
@@ -19,6 +24,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class EstimateUseCase {
 
+    private final FurnitureService furnitureService;
     private final EstimateService estimateService;
     private final AIService aiService;
 
@@ -37,9 +43,22 @@ public class EstimateUseCase {
         return EstimateMapper.fromEstimate(estimate);
     }
 
+    public EstimateItemListResponse getItemList(Long estimateId) {
+        Estimate estimate = estimateService.getEstimateById(estimateId);
+
+        List<EstimateItem> items = estimate.getEstimateItems();
+        List<EstimateItemResponse> list = items.stream().map(EstimateMapper::fromEstimateItem).toList();
+        return EstimateMapper.toEstimateItemListResponse(list);
+    }
+
     @Transactional
     public void updateDefaultInfo(Long estimateId, EstimateUpdateRequest request) {
         Estimate estimate = estimateService.getEstimateById(estimateId);
         estimateService.updateDefaultInfo(estimate, request);
+    }
+
+    @Transactional
+    public void updateFurniture(EstimateItemUpdateRequest request) {
+        furnitureService.updateFurnitureQuantity(request.furnitureId(), request.quantity());
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -58,7 +58,7 @@ public class EstimateUseCase {
     }
 
     @Transactional
-    public void updateFurniture(EstimateItemUpdateRequest request) {
-        furnitureService.updateFurnitureQuantity(request.furnitureId(), request.quantity());
+    public void updateFurniture(Long estimateId, EstimateItemUpdateRequest request) {
+        furnitureService.updateFurnitureQuantity(estimateId, request.furnitureId(), request.quantity());
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -64,6 +64,6 @@ public class EstimateService {
     /* HELPER METHOD */
     private Estimate getOrThrow(Long id) {
         return estimateRepository.findById(id)
-                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND));
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_ESTIMATE));
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -9,9 +9,11 @@ import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateResponse;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
 import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,7 +61,10 @@ public interface EstimateApi {
             success = @ApiSuccessResponseExplanation(
                     responseClass = EstimateItemListResponse.class,
                     description = "수정 성공"
-            )
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INVALID_FURNITURE_ESTIMATE_ASSOCIATION)
+            }
     )
     @PatchMapping("/{estimateId}/furniture")
     ResponseEntity<ApiResponse<EstimateItemListResponse>> updateFurniture(

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -3,14 +3,17 @@ package kr.co.isajjim.domains.estimate.presentation.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.isajjim.domains.estimate.application.request.EstimateItemUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateResponse;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
 import kr.co.isajjim.global.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -45,5 +48,22 @@ public interface EstimateApi {
     ResponseEntity<ApiResponse<EstimateDetailResponse>> updateDefaultInfo(
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateUpdateRequest request
+    );
+
+
+    @Operation(
+            summary = "가구 수량 조정 및 실시간 견적 조회",
+            description = "‘견적서 기본 정보 입력’에서 응답받은 가구 목록을 사용자가 수정하여 실시간으로 견적을 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = EstimateItemListResponse.class,
+                    description = "수정 성공"
+            )
+    )
+    @PatchMapping("/{estimateId}/furniture")
+    ResponseEntity<ApiResponse<EstimateItemListResponse>> updateFurniture(
+            @PathVariable Long estimateId,
+            @RequestBody @Valid EstimateItemUpdateRequest request
     );
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -48,7 +48,7 @@ public class EstimateController implements EstimateApi {
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateItemUpdateRequest request
     ) {
-        estimateUseCase.updateFurniture(request);
+        estimateUseCase.updateFurniture(estimateId, request);
         EstimateItemListResponse response = estimateUseCase.getItemList(estimateId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -1,9 +1,11 @@
 package kr.co.isajjim.domains.estimate.presentation.controller;
 
 import jakarta.validation.Valid;
+import kr.co.isajjim.domains.estimate.application.request.EstimateItemUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateResponse;
 import kr.co.isajjim.domains.estimate.application.usecase.EstimateUseCase;
 import kr.co.isajjim.domains.estimate.presentation.api.EstimateApi;
@@ -37,6 +39,17 @@ public class EstimateController implements EstimateApi {
     ) {
         estimateUseCase.updateDefaultInfo(estimateId, request);
         EstimateDetailResponse response = estimateUseCase.getDetailEstimates(estimateId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @PatchMapping("/{estimateId}/furniture")
+    public ResponseEntity<ApiResponse<EstimateItemListResponse>> updateFurniture(
+            @PathVariable Long estimateId,
+            @RequestBody @Valid EstimateItemUpdateRequest request
+    ) {
+        estimateUseCase.updateFurniture(request);
+        EstimateItemListResponse response = estimateUseCase.getItemList(estimateId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/furniture/FurnitureResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/FurnitureResponse.java
@@ -18,6 +18,6 @@ public record FurnitureResponse(
         FurnitureType type,
 
         @Schema(description = "개수", example = "1")
-        Integer count
+        Integer quantity
 ) {
 }

--- a/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/application/mapper/FurnitureMapper.java
@@ -16,7 +16,7 @@ public class FurnitureMapper {
                 .ratioWidth(info.ratio().w())
                 .ratioDepth(info.ratio().d())
                 .ratioHeight(info.ratio().h())
-                .count(1)
+                .quantity(1)
                 .build();
     }
 
@@ -27,7 +27,7 @@ public class FurnitureMapper {
                 .furnitureId(furniture.getId())
                 .label(furniture.getLabel())
                 .type(furniture.getType())
-                .count(furniture.getCount())
+                .quantity(furniture.getQuantity())
                 .build();
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
@@ -5,6 +5,8 @@ import kr.co.isajjim.domains.furniture.persistence.entity.Furniture;
 import kr.co.isajjim.domains.furniture.persistence.repository.FurnitureRepository;
 import kr.co.isajjim.domains.image.domain.service.ImageService;
 import kr.co.isajjim.domains.image.persistence.entity.Image;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
 import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,17 @@ public class FurnitureService {
         for (AIAnalysisResponse.ImageResult result : imageResults) {
             saveFurniturePerImage(result);
         }
+    }
+
+    public void updateFurnitureQuantity(Long furnitureId, Integer quantity) {
+        Furniture furniture = getOrThrow(furnitureId);
+        furniture.updateQuantity(quantity);
+    }
+
+    /* HELPER METHOD */
+    private Furniture getOrThrow(Long id) {
+        return furnitureRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND));
     }
 
     private void saveFurniturePerImage(AIAnalysisResponse.ImageResult result) {

--- a/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
@@ -37,7 +37,7 @@ public class FurnitureService {
     /* HELPER METHOD */
     private Furniture getOrThrow(Long id) {
         return furnitureRepository.findById(id)
-                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND));
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_FURNITURE));
     }
 
     private void saveFurniturePerImage(AIAnalysisResponse.ImageResult result) {

--- a/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/domain/service/FurnitureService.java
@@ -28,8 +28,9 @@ public class FurnitureService {
         }
     }
 
-    public void updateFurnitureQuantity(Long furnitureId, Integer quantity) {
+    public void updateFurnitureQuantity(Long estimateId, Long furnitureId, Integer quantity) {
         Furniture furniture = getOrThrow(furnitureId);
+        furniture.validateBelongsTo(estimateId);
         furniture.updateQuantity(quantity);
     }
 

--- a/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
@@ -82,7 +82,7 @@ public class Furniture {
 
     public void validateBelongsTo(Long estimateId) {
         if (!this.image.getEstimate().getId().equals(estimateId)) {
-            throw new BaseException(ResponseCode.NOT_FOUND_ESTIMATE);
+            throw new BaseException(ResponseCode.INVALID_FURNITURE_ESTIMATE_ASSOCIATION);
         }
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
 import kr.co.isajjim.domains.furniture.domain.constant.FurnitureType;
 import kr.co.isajjim.domains.image.persistence.entity.Image;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,5 +78,11 @@ public class Furniture {
 
     public void updateQuantity(Integer quantity) {
         this.quantity = quantity;
+    }
+
+    public void validateBelongsTo(Long estimateId) {
+        if (!this.image.getEstimate().getId().equals(estimateId)) {
+            throw new BaseException(ResponseCode.NOT_FOUND_ESTIMATE);
+        }
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
+++ b/src/main/java/kr/co/isajjim/domains/furniture/persistence/entity/Furniture.java
@@ -42,7 +42,7 @@ public class Furniture {
 
     private Double ratioDepth;
 
-    private Integer count;
+    private Integer quantity;
 
     @Builder
     private Furniture(
@@ -54,7 +54,7 @@ public class Furniture {
         Double ratioWidth,
         Double ratioHeight,
         Double ratioDepth,
-        Integer count
+        Integer quantity
     ) {
         this.label = label;
         this.type = type;
@@ -64,7 +64,7 @@ public class Furniture {
         this.ratioWidth = ratioWidth;
         this.ratioHeight = ratioHeight;
         this.ratioDepth = ratioDepth;
-        this.count = count;
+        this.quantity = quantity;
     }
 
     public void setImage(Image image) {
@@ -72,5 +72,9 @@ public class Furniture {
         if (!image.getFurnitures().contains(this)) {
             image.getFurnitures().add(this);
         }
+    }
+
+    public void updateQuantity(Integer quantity) {
+        this.quantity = quantity;
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/image/domain/service/ImageService.java
+++ b/src/main/java/kr/co/isajjim/domains/image/domain/service/ImageService.java
@@ -30,7 +30,7 @@ public class ImageService {
     /* HELPER METHOD */
     private Image getOrThrow(Long id) {
         return imageRepository.findById(id)
-                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND));
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_IMAGE));
     }
 
     public List<Image> getAllByEstimateId(Long estimateId) {

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -16,6 +16,7 @@ public enum ResponseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-001", "잘못된 요청입니다."),
     INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "COMMON-002", "올바르지 않은 요청 형식입니다."),
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "COMMON-003", "데이터 무결성 제약 조건을 위반하였습니다."),
+    INVALID_FURNITURE_ESTIMATE_ASSOCIATION(HttpStatus.BAD_REQUEST, "FURNITURE-001", "가구가 해당 견적서에 해당하지 않습니다."),
 
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-004", "요청 리소스에 대한 접근 권한이 없습니다."),

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ResponseCode {
 
+    /*    COMMON    */
     // 2xx Success
     OK(HttpStatus.OK, "OK", "요청이 성공적으로 처리되었습니다."),
     CREATED(HttpStatus.CREATED, "CREATED", "리소스가 성공적으로 생성되었습니다."),
@@ -16,20 +17,34 @@ public enum ResponseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-001", "잘못된 요청입니다."),
     INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "COMMON-002", "올바르지 않은 요청 형식입니다."),
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "COMMON-003", "데이터 무결성 제약 조건을 위반하였습니다."),
-    INVALID_FURNITURE_ESTIMATE_ASSOCIATION(HttpStatus.BAD_REQUEST, "FURNITURE-001", "가구가 해당 견적서에 해당하지 않습니다."),
 
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-004", "요청 리소스에 대한 접근 권한이 없습니다."),
 
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-005", "요청 리소스를 찾을 수 없습니다."),
-    NOT_FOUND_ESTIMATE(HttpStatus.NOT_FOUND, "ESTIMATE-001", "요청 견적서 ID를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-006", "요청 메소드를 지원하지 않습니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-007", "서버 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+
+
+    /*    FURNITURE    */
+    INVALID_FURNITURE_ESTIMATE_ASSOCIATION(HttpStatus.BAD_REQUEST, "FURNITURE-001", "가구가 해당 견적서에 해당하지 않습니다."),
+
+
+    /*    ESTIMATE    */
+    NOT_FOUND_ESTIMATE(HttpStatus.NOT_FOUND, "ESTIMATE-001", "요청 견적서 ID를 찾을 수 없습니다."),
+
+
+    /*    Furniture    */
+    NOT_FOUND_FURNITURE(HttpStatus.NOT_FOUND, "FURNITURE-001", "요청 가구 ID를 찾을 수 없습니다."),
+
+
+    /*    Image    */
+    NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "IMAGE-001", "요청 이미지 ID를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🚀 개요

- PATCH `/api/v1/estimates/{estimateId}/furniture` API를 구현하였습니다.

## ✨ 작업 내용

- 가구 수정 화면에서 가구별 수량을 변경하는 경우, 변경된 견적 정보를 반환합니다.
- Requset Body
  ```json
  {
    "furnitureId": 7,
    "quantity": 2
  }
  ```
- Response
  ```json
  {
    "code": "OK",
    "message": "요청이 성공적으로 처리되었습니다.",
    "data": {
      "items": [
        {
          "category": "TRUCK",
          "itemType": "TRUCK_1_TON",
          "quantity": 1
        }
      ]
    }
  }
  ```
- 엔티티별 `NOT_FOUND` `RESPONSE_CODE`를 분리하였습니다.
- count 필드를 모두 quantity로 변경하였습니다.