### PR TITLE
🐛 fix: 트랜잭션 범위 문제 해결

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/application/listener/EstimateEventListener.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/listener/EstimateEventListener.java
@@ -1,0 +1,22 @@
+package kr.co.isajjim.domains.estimate.application.listener;
+
+import kr.co.isajjim.domains.estimate.domain.event.EstimateCreatedEvent;
+import kr.co.isajjim.infra.ai.domain.service.AIService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class EstimateEventListener {
+
+    private final AIService aiService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEstimateCreated(EstimateCreatedEvent event) {
+        aiService.analyzeFurniture(event.estimateId(), event.imageDtos());
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -7,14 +7,15 @@ import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemResponse;
+import kr.co.isajjim.domains.estimate.domain.event.EstimateCreatedEvent;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
 import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.annotation.UseCase;
-import kr.co.isajjim.infra.ai.domain.service.AIService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -26,14 +27,14 @@ public class EstimateUseCase {
 
     private final FurnitureService furnitureService;
     private final EstimateService estimateService;
-    private final AIService aiService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Long createAndAnalyze(EstimateRequest request) {
         Long estimateId = estimateService.createEstimate(request);
 
         List<ImageAnalysisDto> imageDtos = estimateService.getImageDtos(estimateId);
-        aiService.analyzeFurniture(estimateId, imageDtos);
+        eventPublisher.publishEvent(new EstimateCreatedEvent(estimateId, imageDtos));
 
         return estimateId;
     }

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/event/EstimateCreatedEvent.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/event/EstimateCreatedEvent.java
@@ -1,0 +1,10 @@
+package kr.co.isajjim.domains.estimate.domain.event;
+
+import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
+
+import java.util.List;
+
+public record EstimateCreatedEvent(
+    Long estimateId,
+    List<ImageAnalysisDto> imageDtos
+) {}

--- a/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
@@ -11,7 +11,6 @@ import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -29,7 +28,6 @@ public class AIService {
     private final FurnitureService furnitureService;
     private final EstimateService estimateService;
 
-    @Async
     public void analyzeFurniture(Long estimateId, List<ImageAnalysisDto> images) {
         try {
             estimateService.updateAIStatus(estimateId, AIStatus.PROCESSING);


### PR DESCRIPTION
## 🚀 개요

- 견적서 생성 시 트랜잭션이 종료되기 전에 가구 분석을 수행하여 견적서 ID를 찾을 수 없는 문제를 해결하였습니다.

## ✨ 작업 내용

- ApplicationEventPublisher을 활용하여 트랜잭션이 종료된 후 가구 분석이 실행될 수 있도록 하였습니다.
  ```java
  eventPublisher.publishEvent(new EstimateCreatedEvent(estimateId, imageDtos));
  ```

  ```java
  @Async
  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
  public void handleEstimateCreated(EstimateCreatedEvent event) {
      aiService.analyzeFurniture(event.estimateId(), event.imageDtos());
  }
  ```