### PR TITLE
♻️ refactor: Short Polling 방식에서 SSE 방식으로 변경

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -8,6 +8,7 @@ import kr.co.isajjim.domains.estimate.application.response.EstimateDetailRespons
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemResponse;
 import kr.co.isajjim.domains.estimate.domain.event.EstimateCreatedEvent;
+import kr.co.isajjim.domains.estimate.domain.service.EstimateNotificationService;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
@@ -17,6 +18,7 @@ import kr.co.isajjim.global.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -27,6 +29,7 @@ public class EstimateUseCase {
 
     private final FurnitureService furnitureService;
     private final EstimateService estimateService;
+    private final EstimateNotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -61,5 +64,16 @@ public class EstimateUseCase {
     @Transactional
     public void updateFurniture(Long estimateId, EstimateItemUpdateRequest request) {
         furnitureService.updateFurnitureQuantity(estimateId, request.furnitureId(), request.quantity());
+    }
+
+    public SseEmitter subscribe(Long estimateId) {
+        SseEmitter emitter = notificationService.createConnection(estimateId);
+
+        // AI 처리가 완료된 경우 즉시 알림 전송
+        if (estimateService.isAIProcessingCompleted(estimateId)) {
+            notificationService.sendNotify(estimateId);
+        }
+
+        return emitter;
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -7,14 +7,17 @@ import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemResponse;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.domain.event.EstimateCreatedEvent;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateNotificationService;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
+import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
 import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,6 +62,12 @@ public class EstimateUseCase {
     public void updateDefaultInfo(Long estimateId, EstimateUpdateRequest request) {
         Estimate estimate = estimateService.getEstimateById(estimateId);
         estimateService.updateDefaultInfo(estimate, request);
+
+        // 프론트 임시 Mock 데이터 반환을 위한 코드
+        AIAnalysisResponse response = getMockData(1L, 2L);
+
+        furnitureService.saveFurnitureList(response.results());
+        estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
     }
 
     @Transactional
@@ -75,5 +84,26 @@ public class EstimateUseCase {
         }
 
         return emitter;
+    }
+
+    private AIAnalysisResponse getMockData(Long imageId1, Long imageId2) {
+        AIAnalysisResponse.ImageResult image1 = new AIAnalysisResponse.ImageResult(
+                imageId1,
+                List.of(
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.BED, 30.5, 20.0, 15.2, 1.0),
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 210.0, 90.0, 85.0, 1.0)
+                )
+        );
+
+        AIAnalysisResponse.ImageResult image2 = new AIAnalysisResponse.ImageResult(
+                imageId2,
+                List.of(
+                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 45.0, 50.0, 90.0, 1.0)
+                )
+        );
+
+        return new AIAnalysisResponse(
+                List.of(image1, image2)
+        );
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -86,6 +86,12 @@ public class EstimateUseCase {
         return emitter;
     }
 
+    @Transactional
+    public void saveFurnitureList(Long estimateId, AIAnalysisResponse request) {
+        furnitureService.saveFurnitureList(request.results());
+        estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
+    }
+
     private AIAnalysisResponse getMockData(Long imageId1, Long imageId2) {
         AIAnalysisResponse.ImageResult image1 = new AIAnalysisResponse.ImageResult(
                 imageId1,

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateNotificationService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateNotificationService.java
@@ -1,0 +1,23 @@
+package kr.co.isajjim.domains.estimate.domain.service;
+
+import kr.co.isajjim.global.sse.SseProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class EstimateNotificationService {
+
+    private static final String EVENT_COMPLETED = "COMPLETED";
+
+    private final SseProvider sseProvider;
+
+    public SseEmitter createConnection(Long estimateId) {
+        return sseProvider.createEmitter(String.valueOf(estimateId));
+    }
+
+    public void sendNotify(Long estimateId) {
+        sseProvider.sendEvent(String.valueOf(estimateId), EVENT_COMPLETED);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -41,6 +41,11 @@ public class EstimateService {
                 .toList();
     }
 
+    public boolean isAIProcessingCompleted(Long estimateId) {
+        Estimate estimate = getOrThrow(estimateId);
+        return estimate.getAiStatus() == AIStatus.COMPLETED;
+    }
+
     public void updateDefaultInfo(Estimate estimate, EstimateUpdateRequest request) {
         estimate.updateEstimate(
                 request.buildingType(),

--- a/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EmitterRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EmitterRepository.java
@@ -1,0 +1,27 @@
+package kr.co.isajjim.domains.estimate.persistence.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class EmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(String id, SseEmitter emitter) {
+        emitters.put(id, emitter);
+    }
+
+    public Map<String, SseEmitter> findAllEmitterStartWithByEstimateId(String estimateId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(estimateId + ":"))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -44,10 +44,13 @@ public interface EstimateApi {
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
+                    //todo 추후 삭제
+                    responseClass = EstimateDetailResponse.class,
                     description = "수정 성공"
             )
     )
-    ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
+//    ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
+    ResponseEntity<ApiResponse<EstimateDetailResponse>> updateDefaultInfo(
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateUpdateRequest request
     );
@@ -68,7 +71,7 @@ public interface EstimateApi {
 
     @Operation(
             summary = "견적서 조회",
-            description = "[견적서 기본 정보 입력]에서 aiStatus이 COMPLETED가 아닌 경우 일정 시간 대기 후 해당 API를 호출하여 동일한 응답을 반환합니다."
+            description = "견적서 조회 구독 후 COMPLETED 응답이 올 경우 호출합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Estimate", description = "견적서 API")
 public interface EstimateApi {
@@ -43,13 +44,26 @@ public interface EstimateApi {
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
-                    responseClass = EstimateDetailResponse.class,
                     description = "수정 성공"
             )
     )
-    ResponseEntity<ApiResponse<EstimateDetailResponse>> updateDefaultInfo(
+    ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateUpdateRequest request
+    );
+
+    @Operation(
+            summary = "견적서 조회 구독(SSE)",
+            description = "성공 응답이 오는 경우에 견적서 조회 API를 호출합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = SseEmitter.class,
+                    description = "조회 성공"
+            )
+    )
+    SseEmitter getEstimateSSE(
+            @PathVariable Long estimateId
     );
 
     @Operation(

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -35,12 +35,15 @@ public class EstimateController implements EstimateApi {
 
     @Override
     @PatchMapping("/{estimateId}")
-    public ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
+//    public ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
+    public ResponseEntity<ApiResponse<EstimateDetailResponse>> updateDefaultInfo(
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateUpdateRequest request
     ) {
         estimateUseCase.updateDefaultInfo(estimateId, request);
-        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+//        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+        EstimateDetailResponse response = estimateUseCase.getDetailEstimates(estimateId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 
     @Override

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -12,8 +12,10 @@ import kr.co.isajjim.domains.estimate.presentation.api.EstimateApi;
 import kr.co.isajjim.global.common.ApiResponse;
 import kr.co.isajjim.global.common.ResponseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/estimates")
@@ -33,13 +35,20 @@ public class EstimateController implements EstimateApi {
 
     @Override
     @PatchMapping("/{estimateId}")
-    public ResponseEntity<ApiResponse<EstimateDetailResponse>> updateDefaultInfo(
+    public ResponseEntity<ApiResponse<Void>> updateDefaultInfo(
             @PathVariable Long estimateId,
             @RequestBody @Valid EstimateUpdateRequest request
     ) {
         estimateUseCase.updateDefaultInfo(estimateId, request);
-        EstimateDetailResponse response = estimateUseCase.getDetailEstimates(estimateId);
-        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+
+    @Override
+    @GetMapping(value = "/{estimateId}/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter getEstimateSSE(
+            @PathVariable Long estimateId
+    ) {
+        return estimateUseCase.subscribe(estimateId);
     }
 
     @Override

--- a/src/main/java/kr/co/isajjim/global/sse/SseProvider.java
+++ b/src/main/java/kr/co/isajjim/global/sse/SseProvider.java
@@ -1,0 +1,60 @@
+package kr.co.isajjim.global.sse;
+
+import kr.co.isajjim.domains.estimate.persistence.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseProvider {
+
+    private static final Long DEFAULT_TIMEOUT = 10 * 60 * 1000L;
+    private static final String DEFAULT_EVENT_NAME = "sse";
+    private static final String DEFAULT_EVENT_CREATED = "EventStream Created.";
+
+    private final EmitterRepository emitterRepository;
+
+    public SseEmitter createEmitter(String key) {
+        String emitterId = makeTimeIncludeId(key);
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(emitterId, emitter);
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+        // 503 에러를 방지하기 위한 더미 이벤트 전송
+        // 연결이 이뤄진 후 하나의 데이터도 전송되지 않는다면, 유효 시간이 끝나면 503이 응답되는 문제가 있음.
+        sendToClient(emitter, emitterId, DEFAULT_EVENT_CREATED);
+
+        return emitter;
+    }
+
+    public void sendEvent(String key, Object data) {
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByEstimateId(key);
+        emitters.forEach((id, emitter) -> sendToClient(emitter, id, data));
+    }
+
+    //===== HELPER METHOD =====
+    private void sendToClient(SseEmitter emitter, String id, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(id)
+                    .name(SseProvider.DEFAULT_EVENT_NAME)
+                    .data(data)
+            );
+        } catch (IOException e) {
+            emitterRepository.deleteById(id);
+            log.warn("SSE Connection Disconnected. id: {}", id);
+        }
+    }
+
+    private String makeTimeIncludeId(String key) {
+        return key + ":" + System.currentTimeMillis();
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
@@ -26,6 +26,9 @@ public class AIService {
     @Value("${infra.ai.base-url}")
     private String url;
 
+    @Value("${infra.ai.use-server}")
+    private Boolean aiServerOn;
+
     private final RestClient restClient;
     private final EstimateService estimateService;
     private final EstimateNotificationService notificationService;
@@ -37,11 +40,13 @@ public class AIService {
             requestBody.put("estimate_id", estimateId);
             requestBody.put("image_urls", images);
 
-            restClient.post()
-                    .uri(url + "/analyze-furniture")
-                    .body(requestBody)
-                    .retrieve()
-                    .body(AIAnalysisResponse.class);
+            if (aiServerOn) {
+                restClient.post()
+                        .uri(url + "/analyze-furniture")
+                        .body(requestBody)
+                        .retrieve()
+                        .body(AIAnalysisResponse.class);
+            }
 
             // Sse 알림 전송;
             notificationService.sendNotify(estimateId);

--- a/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
@@ -3,6 +3,7 @@ package kr.co.isajjim.infra.ai.domain.service;
 import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateNotificationService;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
+import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
@@ -31,7 +32,7 @@ public class AIService {
 
     public void analyzeFurniture(Long estimateId, List<ImageAnalysisDto> images) {
         try {
-            estimateService.updateAIStatus(estimateId, AIStatus.PROCESSING)
+            estimateService.updateAIStatus(estimateId, AIStatus.PROCESSING);
             Map<String, Object> requestBody = new HashMap<>();
             requestBody.put("estimate_id", estimateId);
             requestBody.put("image_urls", images);
@@ -40,7 +41,7 @@ public class AIService {
                     .uri(url + "/analyze-furniture")
                     .body(requestBody)
                     .retrieve()
-                    .body(AIAnalysisResponse.class)
+                    .body(AIAnalysisResponse.class);
 
             // Sse 알림 전송;
             notificationService.sendNotify(estimateId);

--- a/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
+++ b/src/main/java/kr/co/isajjim/infra/ai/domain/service/AIService.java
@@ -1,9 +1,8 @@
 package kr.co.isajjim.infra.ai.domain.service;
 
 import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import kr.co.isajjim.domains.estimate.domain.service.EstimateNotificationService;
 import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
-import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
-import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
@@ -14,7 +13,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -25,53 +26,28 @@ public class AIService {
     private String url;
 
     private final RestClient restClient;
-    private final FurnitureService furnitureService;
     private final EstimateService estimateService;
+    private final EstimateNotificationService notificationService;
 
     public void analyzeFurniture(Long estimateId, List<ImageAnalysisDto> images) {
         try {
             estimateService.updateAIStatus(estimateId, AIStatus.PROCESSING);
-            /*
             Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("estimate_id", estimateId);
             requestBody.put("image_urls", images);
 
-            AIAnalysisResponse response = restClient.post()
+            restClient.post()
                     .uri(url + "/analyze-furniture")
                     .body(requestBody)
                     .retrieve()
                     .body(AIAnalysisResponse.class);
-            */
 
-            // Mock Data 이용
-            AIAnalysisResponse response = getMockData(images.get(0).id(), images.get(1).id());
-
-            furnitureService.saveFurnitureList(response.results());
-            estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
+            // Sse 알림 전송;
+            notificationService.sendNotify(estimateId);
         } catch (Exception e) {
             log.error("AI 분석 중 오류 발생: {}", e.getMessage());
             estimateService.updateAIStatus(estimateId, AIStatus.FAILED);
             throw new BaseException(ResponseCode.INTERNAL_SERVER_ERROR);
         }
-    }
-
-    private AIAnalysisResponse getMockData(Long imageId1, Long imageId2) {
-        AIAnalysisResponse.ImageResult image1 = new AIAnalysisResponse.ImageResult(
-                imageId1,
-                List.of(
-                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.BED, 30.5, 20.0, 15.2),
-                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 210.0, 90.0, 85.0)
-                )
-        );
-
-        AIAnalysisResponse.ImageResult image2 = new AIAnalysisResponse.ImageResult(
-                imageId2,
-                List.of(
-                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 45.0, 50.0, 90.0)
-                )
-        );
-
-        return new AIAnalysisResponse(
-                List.of(image1, image2)
-        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,4 @@ rest-client:
 infra:
   ai:
     base-url: ${AI_BASE_URL}
+    use-server: ${AI_USE_SERVER}


### PR DESCRIPTION
## 🚀 개요

- 기존 가구 분석 요청 시 프론트에서 Short Polling 방식으로 가져가던 흐름을 SSE(Server-Sent-Event)방식으로 변경하였습니다.

## ✨ 작업 내용

- 기존 흐름 : 견적서 생성 -> 기본 정보 입력하여 동기식으로 분석된 가구 목록 반환
- 변경 흐름 : 견적서 생성 -> 기본 정보 입력 -> sse 구독 -> COMPLETED 된 경우 GET 호출
- 동기식 처리가 아닌 SSE 방식을 이용하여 서버 부하를 감소하였습니다.
- 프론트 API 호출 흐름
1. 견적서 생성 요청하여 견적서 ID 반환 (POST `/api/v1/estimates`)
2. 견적서 기본 정보 입력 (PATCH `/api/v1/estimates/{estimateId}`)
3. 견적서 조회 구독 (GET `/api/v1/estimates/{estimateId}/sse`)
4. EventSource에서 COMPLTETD 응답이 올 경우 견적서 조회 호출 (GET `/api/v1/estimates/{estimateId}`)
- 프론트에서 추가 구현 작업이 필요하여 일단 견적서 기본 정보 입력시 동기식으로 반환하는 코드는 남겨두었습니다.
- 응답 데이터 흐름
  ```
  // 1. 초기 연결 시 (503 방지용)
  id: 31:1769135674221
  event: sse
  data: EventStream Created.
  
  // 2. AI 분석 완료 시 (상태 알림)
  id: 31:1769135674221
  event: sse
  data: COMPLETED
  ```

- 프론트 코드 예시
  ```js
  const eventSource = new EventSource('/api/v1/estimates/{estimateId}/sse');
  
  // 초기 연결 확인
  eventSource.addEventListener('sse', (event) => {
      console.log('연결 성공:', event.data);
  });
  
  // AI 분석 완료 이벤트 처리
  eventSource.addEventListener('COMPLETED', (event) => {
      console.log('AI 분석이 완료되었습니다.');
      
      // 1. 필요한 후속 로직 실행 (예: 데이터 다시 불러오기 등)
      fetchEstimateDetails(estimateId);
  
      // 2. 중요: 완료 후 반드시 SSE 연결 종료
      eventSource.close(); 
      console.log('SSE 연결이 클라이언트에 의해 종료되었습니다.');
  });
  
  eventSource.onerror = (error) => {
      console.error('SSE 에러 발생:', error);
      eventSource.close();
  };
  ```