### PR TITLE
🐛 fix: 목데이터 오류 해결

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -16,6 +16,7 @@ import kr.co.isajjim.domains.estimate.persistence.entity.EstimateItem;
 import kr.co.isajjim.domains.furniture.domain.constant.FurnitureLabel;
 import kr.co.isajjim.domains.furniture.domain.service.FurnitureService;
 import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
+import kr.co.isajjim.domains.image.persistence.entity.Image;
 import kr.co.isajjim.global.annotation.UseCase;
 import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import lombok.RequiredArgsConstructor;
@@ -64,7 +65,8 @@ public class EstimateUseCase {
         estimateService.updateDefaultInfo(estimate, request);
 
         // 프론트 임시 Mock 데이터 반환을 위한 코드
-        AIAnalysisResponse response = getMockData(1L, 2L);
+        List<Long> list = estimate.getImages().stream().map(Image::getId).toList();
+        AIAnalysisResponse response = getMockData(list);
 
         furnitureService.saveFurnitureList(response.results());
         estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
@@ -92,24 +94,17 @@ public class EstimateUseCase {
         estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
     }
 
-    private AIAnalysisResponse getMockData(Long imageId1, Long imageId2) {
-        AIAnalysisResponse.ImageResult image1 = new AIAnalysisResponse.ImageResult(
-                imageId1,
+    private AIAnalysisResponse getMockData(List<Long> imageIds) {
+        List<AIAnalysisResponse.ImageResult> list = imageIds.stream().map(id -> new AIAnalysisResponse.ImageResult(
+                id,
                 List.of(
                         new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.BED, 30.5, 20.0, 15.2, 1.0),
                         new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 210.0, 90.0, 85.0, 1.0)
                 )
-        );
-
-        AIAnalysisResponse.ImageResult image2 = new AIAnalysisResponse.ImageResult(
-                imageId2,
-                List.of(
-                        new AIAnalysisResponse.FurnitureInfo(FurnitureLabel.TV, 45.0, 50.0, 90.0, 1.0)
-                )
-        );
+        )).toList();
 
         return new AIAnalysisResponse(
-                List.of(image1, image2)
+                list
         );
     }
 }


### PR DESCRIPTION
## 🚀 개요

- 프론트와 작업 시 필요한 Mock 데이터를 견적서의 실제 이미지 id목록을 받아와 매칭하는 것으로 수정하였습니다.