### PR TITLE
🔧 chore: HTTPS 환경 구성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,6 +70,7 @@ jobs:
             IMAGE_PATH="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
             IMAGE_PATH="${IMAGE_PATH,,}"
             sed -i "s|image: ${IMAGE_PATH}:.*|image: ${IMAGE_PATH}:${RELEASE_VERSION#v}|g" docker-compose.yml
+            sed -i "s|NGINX_HOST|${{ secrets.HOST }}|g" ./configs/nginx/default.conf
             
             mv ./configs/.env ./
 

--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -1,0 +1,32 @@
+# HTTP -> HTTPS redirection
+server {
+    listen 80;
+    server_name NGINX_HOST;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS main
+server {
+    listen 443 ssl;
+    server_name NGINX_HOST;
+
+    ssl_certificate /etc/letsencrypt/live/NGINX_HOST/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/NGINX_HOST/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://spring:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -24,6 +24,15 @@ server {
 
     location / {
         proxy_pass http://spring:8080;
+
+		# SSE 관련 설정
+		proxy_buffering off;      # 데이터를 모으지 않고 즉시 전달
+		proxy_cache off;          # 캐싱 방지
+		chunked_transfer_encoding on;
+
+		# 연결 유지 시간 설정
+		proxy_read_timeout 600s;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    networks:
+      - backend
     volumes:
       - ./configs/nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./configs/certbot/conf:/etc/letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,25 @@ services:
       - SPRING_CONFIG_ADDITIONAL-LOCATION=file:/configs/
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILE:-local}
 
+  nginx:
+    image: nginx:stable-alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./configs/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./configs/certbot/conf:/etc/letsencrypt
+      - ./configs/certbot/www:/var/www/certbot
+    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
+
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    volumes:
+      - ./configs/certbot/conf:/etc/letsencrypt
+      - ./configs/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait $${!}; done;'"
+
 networks:
   backend:


### PR DESCRIPTION
## 🚀 개요

- API 요청 보안을 위하여 HTTPS 환경을 구성하였습니다.

## ✨ 작업 내용

- 외부 API 요청 "https://api.isajjim.kro.kr/api/v1..." -> docker의 nginx로 전달 -> default.conf 설정 파일을 기반으로 ssl 인증서 적용 -> 내부 http://spring:8080 으로 요청 -> nginx로 반환
- certbot이 자동으로 인증서 만료일 전 갱신
- 서버에 Let's Encrypt 인증서 발급완료

## 💡 기술적 사항

- 인증서 발급 방법
```
# Let's Encrypt 인증서 발급
sudo apt-get update && sudo apt-get install certbot -y
sudo certbot certonly --standalone -d api.isajjim.kro.kr

# 인증서 복사
sudo cp -a /etc/letsencrypt/live/api.isajjim.kro.kr ~/configs/certbot/conf/live/
sudo cp -a /etc/letsencrypt/archive/api.isajjim.kro.kr ~/configs/certbot/conf/archive/

# 트러블슈팅 : optional-ssl-nginx.conf, ssl-dhparams.pem 임의 생성
https://hyotatofrappuccino.tistory.com/193

# Docker Compose Container 설정
nginx:
  image: nginx:stable-alpine
  container_name: nginx
  ports:
    - "80:80"
    - "443:443"
  volumes:
    - ./configs/nginx/default.conf:/etc/nginx/conf.d/default.conf
    - ./configs/certbot/conf:/etc/letsencrypt
    - ./configs/certbot/www:/var/www/certbot
  command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''

certbot:
  image: certbot/certbot
  container_name: certbot
  volumes:
    - ./configs/certbot/conf:/etc/letsencrypt
    - ./configs/certbot/www:/var/www/certbot
  entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait $${!}; done;'"

nginx default.conf 설정
# HTTP -> HTTPS redirection
server {
    listen 80;
    server_name NGINX_HOST;

    location /.well-known/acme-challenge/ {
        root /var/www/certbot;
    }

    location / {
        return 301 https://$host$request_uri;
    }
}

# HTTPS main
server {
    listen 443 ssl;
    server_name NGINX_HOST;

    ssl_certificate /etc/letsencrypt/live/NGINX_HOST/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/NGINX_HOST/privkey.pem;
    include /etc/letsencrypt/options-ssl-nginx.conf;
    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

    location / {
        proxy_pass http://spring:8080;

		# SSE 관련 설정
		proxy_buffering off;      # 데이터를 모으지 않고 즉시 전달
		proxy_cache off;          # 캐싱 방지
		chunked_transfer_encoding on;

		# 연결 유지 시간 설정
		proxy_read_timeout 600s;

        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}

# cd.yml 에서 nginx 설정의 NGINX_HOST를 실제 주소로 대체
sed -i "s|NGINX_HOST|${{ secrets.HOST }}|g" ./configs/nginx/default.conf
```