### PR TITLE
✨ feat: Google Cloud Storage Presigned Url 발급 구현(이미지 업로드 속도 개선)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,7 @@ jobs:
           mkdir -p configs/
           
           echo "${{ secrets.ENV }}" | base64 --decode > configs/.env
+          echo "${{ secrets.GCS_KEY }}" | base64 --decode > configs/gcsKey.json
           echo "" >> configs/.env
           echo "SPRING_PROFILE=${{ vars.SPRING_PROFILE }}" >> configs/.env
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Google
+    implementation 'com.google.cloud:google-cloud-storage:2.62.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/kr/co/isajjim/global/config/gcs/GcsConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/gcs/GcsConfig.java
@@ -1,0 +1,40 @@
+package kr.co.isajjim.global.config.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+@RequiredArgsConstructor
+public class GcsConfig {
+
+    @Value("${infra.google.project-id}")
+    private String projectId;
+
+    @Value("${infra.google.gcs.key-path}")
+    private String keyPath;
+
+    private final ResourceLoader resourceLoader;
+
+    @Bean
+    public Storage storage() throws IOException {
+        Resource resource = resourceLoader.getResource(keyPath);
+        InputStream serviceAccount = resource.getInputStream();
+        GoogleCredentials credentials = GoogleCredentials.fromStream(serviceAccount);
+
+        return StorageOptions.newBuilder()
+                .setCredentials(credentials)
+                .setProjectId(projectId)
+                .build()
+                .getService();
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlListResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlListResponse.java
@@ -1,0 +1,13 @@
+package kr.co.isajjim.infra.google.gcs.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PresignedUrlListResponse(
+        @Schema(description = "Presigned Url 목록")
+        List<PresignedUrlResponse> urls
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlRequest.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlRequest.java
@@ -1,0 +1,13 @@
+package kr.co.isajjim.infra.google.gcs.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PresignedUrlRequest(
+        @NotBlank(message = "파일 이름은 비어있을 수 없습니다.")
+        @Size(max = 100, message = "파일 이름은 100자 이하여야 합니다.")
+        @Schema(description = "파일 이름", example = "1.jpg")
+        String fileName
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlRequest.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlRequest.java
@@ -2,12 +2,21 @@ package kr.co.isajjim.infra.google.gcs.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public record PresignedUrlRequest(
-        @NotBlank(message = "파일 이름은 비어있을 수 없습니다.")
-        @Size(max = 100, message = "파일 이름은 100자 이하여야 합니다.")
-        @Schema(description = "파일 이름", example = "1.jpg")
-        String fileName
+        @NotEmpty(message = "최소 하나 이상의 파일명이 필요합니다.")
+        @Size(max = 100, message = "한 번에 최대 100개까지 요청 가능합니다.")
+        @Schema(
+                description = "파일 이름 목록(확장자 포함)",
+                example = "[\"1.jpg\", \"2.jpg\"]"
+        )
+        List<
+            @NotBlank(message = "파일 이름은 비어있을 수 없습니다.")
+            @Size(max = 100, message = "파일 이름은 100자 이하여야 합니다.")
+            String> fileNames
 ) {
 }

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlResponse.java
@@ -14,7 +14,7 @@ public record PresignedUrlResponse(
         @Schema(description = "업로드 후 파일 접근 URL", example = "https://storage.googleapis.com/bucket-name/73af9_1.jpg")
         String fileUrl,
 
-        @Schema(description = "파일 고유 Key", example = "1/73af9_1.jpg")
+        @Schema(description = "파일 고유 Key", example = "73af9_1.jpg")
         String key
 ) {
 }

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/dto/PresignedUrlResponse.java
@@ -1,0 +1,20 @@
+package kr.co.isajjim.infra.google.gcs.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.net.URL;
+
+@Builder
+public record PresignedUrlResponse(
+
+        @Schema(description = "파일 업로드를 위한 URL", example = "https://storage.googleapis.com/bucket-name/73af9_1.jpg")
+        URL presignedUrl,
+
+        @Schema(description = "업로드 후 파일 접근 URL", example = "https://storage.googleapis.com/bucket-name/73af9_1.jpg")
+        String fileUrl,
+
+        @Schema(description = "파일 고유 Key", example = "1/73af9_1.jpg")
+        String key
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/mapper/GcsMapper.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/mapper/GcsMapper.java
@@ -1,8 +1,10 @@
 package kr.co.isajjim.infra.google.gcs.application.mapper;
 
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlListResponse;
 import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
 
 import java.net.URL;
+import java.util.List;
 
 public class GcsMapper {
 
@@ -11,6 +13,14 @@ public class GcsMapper {
                 .presignedUrl(presignedUrl)
                 .fileUrl(fileUrl)
                 .key(key)
+                .build();
+    }
+
+    public static PresignedUrlListResponse toPresignedUrlListResponse(
+            List<PresignedUrlResponse> urls
+    ) {
+        return PresignedUrlListResponse.builder()
+                .urls(urls)
                 .build();
     }
 }

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/mapper/GcsMapper.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/mapper/GcsMapper.java
@@ -1,0 +1,16 @@
+package kr.co.isajjim.infra.google.gcs.application.mapper;
+
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
+
+import java.net.URL;
+
+public class GcsMapper {
+
+    public static PresignedUrlResponse toPresignedUrlResponse(URL presignedUrl, String fileUrl, String key) {
+        return PresignedUrlResponse.builder()
+                .presignedUrl(presignedUrl)
+                .fileUrl(fileUrl)
+                .key(key)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/usecase/GcsUseCase.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/usecase/GcsUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.isajjim.infra.google.gcs.application.usecase;
 
 import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlListResponse;
 import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
 import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
 import kr.co.isajjim.infra.google.gcs.application.mapper.GcsMapper;
@@ -8,6 +9,7 @@ import kr.co.isajjim.infra.google.gcs.domain.service.GcsService;
 import lombok.RequiredArgsConstructor;
 
 import java.net.URL;
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -15,18 +17,23 @@ public class GcsUseCase {
 
     private final GcsService gcsService;
 
-    public PresignedUrlResponse generatePresignedUrl(
+    public PresignedUrlListResponse generatePresignedUrl(
             PresignedUrlRequest request
     ) {
-        String fileName = request.fileName();
-        //todo AI 서버에서 지원하는 확장자 검증
-//        validSupportedExtension(fileName);
+        List<PresignedUrlResponse> list = request.fileNames().stream().map(
+                fileName -> {
+                    //todo AI 서버에서 지원하는 확장자 검증
+                    //validSupportedExtension(fileName);
 
-        String key = gcsService.createKey(fileName);
-        URL presignedUrl = gcsService.generatePresignedUrl(key);
-        String fileUrl = gcsService.generateFileUrl(key);
+                    String key = gcsService.createKey(fileName);
+                    URL presignedUrl = gcsService.generatePresignedUrl(key);
+                    String fileUrl = gcsService.generateFileUrl(key);
 
-        return GcsMapper.toPresignedUrlResponse(presignedUrl, fileUrl, key);
+                    return GcsMapper.toPresignedUrlResponse(presignedUrl, fileUrl, key);
+                }
+        ).toList();
+
+        return GcsMapper.toPresignedUrlListResponse(list);
     }
 
 //    private void validSupportedExtension(String fileName) {

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/application/usecase/GcsUseCase.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/application/usecase/GcsUseCase.java
@@ -1,0 +1,37 @@
+package kr.co.isajjim.infra.google.gcs.application.usecase;
+
+import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
+import kr.co.isajjim.infra.google.gcs.application.mapper.GcsMapper;
+import kr.co.isajjim.infra.google.gcs.domain.service.GcsService;
+import lombok.RequiredArgsConstructor;
+
+import java.net.URL;
+
+@UseCase
+@RequiredArgsConstructor
+public class GcsUseCase {
+
+    private final GcsService gcsService;
+
+    public PresignedUrlResponse generatePresignedUrl(
+            PresignedUrlRequest request
+    ) {
+        String fileName = request.fileName();
+        //todo AI 서버에서 지원하는 확장자 검증
+//        validSupportedExtension(fileName);
+
+        String key = gcsService.createKey(fileName);
+        URL presignedUrl = gcsService.generatePresignedUrl(key);
+        String fileUrl = gcsService.generateFileUrl(key);
+
+        return GcsMapper.toPresignedUrlResponse(presignedUrl, fileUrl, key);
+    }
+
+//    private void validSupportedExtension(String fileName) {
+//        if (!Objects.equals(StringUtils.getFilenameExtension(fileName), "pdf")) {
+//            throw new BaseException(ResponseCode.NOT_SUPPORTED_EXTENSION);
+//        }
+//    }
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/domain/service/GcsService.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/domain/service/GcsService.java
@@ -1,0 +1,59 @@
+package kr.co.isajjim.infra.google.gcs.domain.service;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class GcsService {
+
+    private final Storage storage;
+
+    @Value("${infra.google.gcs.bucket}")
+    private String bucketName;
+
+    public URL generatePresignedUrl(String key) {
+        String contentType = URLConnection.guessContentTypeFromName(key);
+        if (contentType == null) {
+            contentType = "application/octet-stream";
+        }
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, key).build();
+
+        Map<String, String> extensionHeaders = new HashMap<>();
+        extensionHeaders.put("Content-Type", contentType);
+
+        return storage.signUrl(
+                blobInfo,
+                15,
+                TimeUnit.MINUTES,
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                Storage.SignUrlOption.withExtHeaders(extensionHeaders),
+                Storage.SignUrlOption.withV4Signature()
+        );
+    }
+
+    public String createKey(String fileName) {
+        return createUniqueFileName(fileName);
+    }
+
+    public String generateFileUrl(String key) {
+        return String.format("https://storage.googleapis.com/%s/%s", bucketName, key);
+    }
+
+    /* HELPER METHOD */
+    private String createUniqueFileName(String originalFileName) {
+        return String.format("%s_%s", UUID.randomUUID(), originalFileName);
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
@@ -1,6 +1,7 @@
 package kr.co.isajjim.infra.google.gcs.presentation.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -10,6 +11,7 @@ import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "GCS", description = "GCS API")
 public interface GcsApi {
 
     @Operation(

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
@@ -5,8 +5,8 @@ import jakarta.validation.Valid;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
 import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlListResponse;
 import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
-import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -18,11 +18,11 @@ public interface GcsApi {
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
-                    responseClass = PresignedUrlResponse.class,
+                    responseClass = PresignedUrlListResponse.class,
                     description = "발급 성공"
             )
     )
-    ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+    ResponseEntity<ApiResponse<PresignedUrlListResponse>> getPresignedUrl(
             @RequestBody @Valid PresignedUrlRequest request
     );
 }

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/api/GcsApi.java
@@ -1,0 +1,28 @@
+package kr.co.isajjim.infra.google.gcs.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface GcsApi {
+
+    @Operation(
+            summary = "Presigned Url 발급",
+            description = "발급 후 presignedUrl을 PUT 요청으로 클라이언트에서 파일을 gcs에 업로드한 후, 응답받은 fileUrl 목록을 견적서 생성 시 첨부합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PresignedUrlResponse.class,
+                    description = "발급 성공"
+            )
+    )
+    ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @RequestBody @Valid PresignedUrlRequest request
+    );
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/controller/GcsController.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/controller/GcsController.java
@@ -1,0 +1,32 @@
+package kr.co.isajjim.infra.google.gcs.presentation.controller;
+
+import jakarta.validation.Valid;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
+import kr.co.isajjim.infra.google.gcs.application.usecase.GcsUseCase;
+import kr.co.isajjim.infra.google.gcs.presentation.api.GcsApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/gcs")
+@RequiredArgsConstructor
+public class GcsController implements GcsApi {
+
+    private final GcsUseCase gcsUseCase;
+
+    @Override
+    @PostMapping("/presigned")
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @RequestBody @Valid PresignedUrlRequest request
+    ) {
+        PresignedUrlResponse signedUrl = gcsUseCase.generatePresignedUrl(request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, signedUrl));
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/controller/GcsController.java
+++ b/src/main/java/kr/co/isajjim/infra/google/gcs/presentation/controller/GcsController.java
@@ -3,8 +3,8 @@ package kr.co.isajjim.infra.google.gcs.presentation.controller;
 import jakarta.validation.Valid;
 import kr.co.isajjim.global.common.ApiResponse;
 import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlListResponse;
 import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlRequest;
-import kr.co.isajjim.infra.google.gcs.application.dto.PresignedUrlResponse;
 import kr.co.isajjim.infra.google.gcs.application.usecase.GcsUseCase;
 import kr.co.isajjim.infra.google.gcs.presentation.api.GcsApi;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +23,10 @@ public class GcsController implements GcsApi {
 
     @Override
     @PostMapping("/presigned")
-    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+    public ResponseEntity<ApiResponse<PresignedUrlListResponse>> getPresignedUrl(
             @RequestBody @Valid PresignedUrlRequest request
     ) {
-        PresignedUrlResponse signedUrl = gcsUseCase.generatePresignedUrl(request);
+        PresignedUrlListResponse signedUrl = gcsUseCase.generatePresignedUrl(request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, signedUrl));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ infra:
     project-id: ${GOOGLE_PROJECT_ID}
     gcs:
       key-path: file:configs/gcsKey.json
+      bucket: ${GOOGLE_GCS_BUCKET}
 
 estimate:
   extra-volume-ratio: ${ESTIMATE_EXTRA_VOLUME_RATIO}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ infra:
   ai:
     base-url: ${AI_BASE_URL}
     use-server: ${AI_USE_SERVER}
+  google:
+    project-id: ${GOOGLE_PROJECT_ID}
+    gcs:
+      key-path: file:configs/gcsKey.json
 
 estimate:
   extra-volume-ratio: ${ESTIMATE_EXTRA_VOLUME_RATIO}


### PR DESCRIPTION
## 🚀 개요

- 기존 흐름 : 프론트엔드에서 Firebase Storage에 직접 이미지 업로드 -> 백엔드로 이미지 URL 전송 -> AI 서버에 전달하여 분석
- 문제점 : FIrebase Storage는 내부적으로 Google Cloud Storage를 사용. 이 과정에서 Firebase가 Cloud Storage에 업로드 하기 위해 내부적으로 토큰, 보안 규칙(Security Rules)을 검증하는 과정을 거치는 것으로 보이는데, 이로 인해 업로드 속도가 비정상적으로 오래 걸리는 문제가 발생함. 

1) 244KB의 이미지를 React Native에서 FIrebase Storage에 업로드 : 1초 이상의 서버 대기 시간 발생
<img width="2255" height="393" alt="PR1" src="https://github.com/user-attachments/assets/fc7974f6-6374-4a30-8f8e-9ae081b4bd0b" />

2) Google Cloud Storage에 직접 업로드 시, 서버 응답 대기 시간이 100ms에 불과(첫 요청 또한 244ms)
<img width="2273" height="422" alt="PR2" src="https://github.com/user-attachments/assets/b4782a12-eec9-4da4-b287-218e05842af4" />

3) AWS S3 또한 직접 업로드 시, 서버 응답 대기 시간이 100ms수준
<img width="2271" height="395" alt="PR3" src="https://github.com/user-attachments/assets/cbba6a71-2b76-409c-862d-7acc6cf25569" />

이에 따라 Firebase Storage를 사용하지 않고, 직접 Cloud Storage에 업로드 하는것으로 결정

## ✨ 작업 내용

- GCS Presigned Url 발급 구현
- 구글 서비스 계정 키 발급 : configs/gcsKey.json
- API 추가 : /api/v1/gcs/presigned
```json
// Request
{
  "fileNames": [
    "1.jpg",
    "2.jpg"
  ]
}

// Response
{
  "code": "OK",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "urls": [
      {
        "presignedUrl": "https://storage.googleapis.com/bucket-name/73af9_1.jpg",
        "fileUrl": "https://storage.googleapis.com/bucket-name/73af9_1.jpg",
        "key": "73af9_1.jpg"
      },
      {
        "presignedUrl": "https://storage.googleapis.com/bucket-name/73af9_2.jpg",
        "fileUrl": "https://storage.googleapis.com/bucket-name/73af9_2.jpg",
        "key": "73af9_2.jpg"
      }
    ]
  }
}
```