### PR TITLE
✨ feat: 업체 대화 AI 요약 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,16 @@
-DEV_SWAGGER_URL=https://dev.isajjim.co.kr
+SPRING_PROFILES_ACTIVE=dev
+
+DB_URL=jdbc:h2:mem:isajjim
+DB_USERNAME=sa
+DB_PASSWORD=
+
+FRONTEND_URL=https://isajjim.kro.kr
+DEV_SWAGGER_URL=https://api.isajjim.kro.kr
+
+AI_BASE_URL=http://api-ai.isajjim.kro.kr:8000
+AI_USE_SERVER=true
+GOOGLE_PROJECT_ID=
+GOOGLE_GCS_BUCKET=
 GEMINI_API_KEY=
+
+ESTIMATE_EXTRA_VOLUME_RATIO=1.1

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DEV_SWAGGER_URL=https://dev.isajjim.co.kr
+GEMINI_API_KEY=

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
     // Google
     implementation 'com.google.cloud:google-cloud-storage:2.62.0'
+    implementation 'com.google.genai:google-genai:1.37.0'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateChatSummaryMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateChatSummaryMapper.java
@@ -1,0 +1,13 @@
+package kr.co.isajjim.domains.estimate.application.mapper;
+
+import kr.co.isajjim.domains.estimate.application.response.EstimateChatSummaryResponse;
+
+public class EstimateChatSummaryMapper {
+    public static EstimateChatSummaryResponse toEstimateChatSummaryResponse(
+            String summary
+    ) {
+        return EstimateChatSummaryResponse.builder()
+                .summary(summary)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/response/EstimateChatSummaryResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/response/EstimateChatSummaryResponse.java
@@ -1,0 +1,9 @@
+package kr.co.isajjim.domains.estimate.application.response;
+
+import lombok.Builder;
+
+@Builder
+public record EstimateChatSummaryResponse(
+        String summary
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/EstimateUseCase.java
@@ -1,7 +1,9 @@
 package kr.co.isajjim.domains.estimate.application.usecase;
 
+import kr.co.isajjim.domains.estimate.application.mapper.EstimateChatSummaryMapper;
 import kr.co.isajjim.domains.estimate.application.mapper.EstimateMapper;
 import kr.co.isajjim.domains.estimate.application.request.*;
+import kr.co.isajjim.domains.estimate.application.response.EstimateChatSummaryResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.domain.event.EstimateCreatedEvent;
@@ -76,5 +78,10 @@ public class EstimateUseCase {
         furnitureService.saveFurnitureList(request.results());
         estimateService.updateAIStatus(estimateId, AIStatus.COMPLETED);
         notificationService.sendNotify(estimateId);
+    }
+
+    public EstimateChatSummaryResponse generateChatSummary(Long estimateId, String chatContent) {
+        String summary = estimateService.generateChatSummary(estimateId, chatContent);
+        return EstimateChatSummaryMapper.toEstimateChatSummaryResponse(summary);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -14,6 +14,7 @@ import kr.co.isajjim.domains.image.application.response.ImageAnalysisDto;
 import kr.co.isajjim.domains.image.domain.service.ImageService;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.global.llm.LlmProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class EstimateService {
 
     private final EstimateRepository estimateRepository;
     private final ImageService imageService;
+    private final LlmProvider llmProvider;
 
     public Estimate getEstimateById(Long estimateId) {
         return getOrThrow(estimateId);
@@ -69,6 +71,25 @@ public class EstimateService {
     public void updateAIStatus(Long estimateId, AIStatus status) {
         Estimate estimate = getOrThrow(estimateId);
         estimate.updateAIStatus(status);
+    }
+
+    public String generateChatSummary(Long estimateId, String chatContent) {
+        Estimate estimate = getOrThrow(estimateId);
+
+        String prompt = String.format(
+                "역할: 이사 전문 상담 요약가\n" +
+                        "다음 정보를 바탕으로(특히 대화 내용 중심) 이사 견적 확정 사항을 요약해줘. 최종 응답의 앞뒤에 '안녕하세요 이사 전문 상담 요약가입니다 ~를 요약해드릴게요, 편안한 이사 되세요' 등의 미사어구 없이 내용 자체만 요약해줘.\n\n" +
+                        "1. 출발지: %s\n" +
+                        "2. 도착지: %s\n" +
+                        "3. 이사일: %s\n" +
+                        "4. 대화 내용:\n%s",
+                estimate.getStartLocation(),
+                estimate.getEndLocation(),
+                estimate.getPreferredMovingDate(),
+                chatContent
+        );
+
+        return llmProvider.llmCall(prompt);
     }
 
     /* HELPER METHOD */

--- a/src/main/java/kr/co/isajjim/domains/estimate/persistence/entity/LocationDetail.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/persistence/entity/LocationDetail.java
@@ -89,4 +89,21 @@ public class LocationDetail extends BaseEntity {
         this.groundStair = (request.groundStair() != null) ? request.groundStair() : this.groundStair;
         this.parking = (request.parking() != null) ? request.parking() : this.parking;
     }
+
+    @Override
+    public String toString() {
+        return "LocationDetail{" +
+                "address='" + address + '\'' +
+                ", detailAddress='" + detailAddress + '\'' +
+                ", buildingType=" + buildingType +
+                ", roomSize=" + roomSize +
+                ", floor=" + floor +
+                ", elevator=" + elevator +
+                ", ladderTruck=" + ladderTruck +
+                ", roomType=" + roomType +
+                ", duplex=" + duplex +
+                ", groundStair=" + groundStair +
+                ", parking=" + parking +
+                '}';
+    }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -7,6 +7,7 @@ import kr.co.isajjim.domains.estimate.application.request.EstimateFurnitureUpdat
 import kr.co.isajjim.domains.estimate.application.request.EstimateItemUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateUpdateRequest;
+import kr.co.isajjim.domains.estimate.application.response.EstimateChatSummaryResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateResponse;
 import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
@@ -18,6 +19,7 @@ import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -118,5 +120,20 @@ public interface EstimateApi {
     ResponseEntity<ApiResponse<Void>> aiCallback(
             @PathVariable Long estimateId,
             @RequestBody AIAnalysisResponse request
+    );
+
+    @Operation(
+            summary = "대화 내용 요약 LLM 호출"
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = EstimateChatSummaryResponse.class,
+                    description = "응답 성공"
+            )
+    )
+    @PostMapping("/{estimateId}/chat-summary")
+    ResponseEntity<ApiResponse<EstimateChatSummaryResponse>> chatSummary(
+            @PathVariable Long estimateId,
+            @RequestBody String chatContent
     );
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -2,6 +2,7 @@ package kr.co.isajjim.domains.estimate.presentation.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.co.isajjim.domains.estimate.application.request.EstimateFurnitureUpdateRequest;
 import kr.co.isajjim.domains.estimate.application.request.EstimateItemUpdateRequest;
@@ -68,7 +69,8 @@ public interface EstimateApi {
             )
     )
     SseEmitter getEstimateSSE(
-            @PathVariable Long estimateId
+            @PathVariable Long estimateId,
+            HttpServletResponse response
     );
 
     @Operation(

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -2,6 +2,7 @@ package kr.co.isajjim.domains.estimate.presentation.controller;
 
 import jakarta.validation.Valid;
 import kr.co.isajjim.domains.estimate.application.request.*;
+import kr.co.isajjim.domains.estimate.application.response.EstimateChatSummaryResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateResponse;
 import kr.co.isajjim.domains.estimate.application.usecase.EstimateUseCase;
@@ -86,5 +87,15 @@ public class EstimateController implements EstimateApi {
     ) {
         estimateUseCase.saveFurnitureList(estimateId, request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+
+    @Override
+    @PostMapping("/{estimateId}/chat-summary")
+    public ResponseEntity<ApiResponse<EstimateChatSummaryResponse>> chatSummary(
+            @PathVariable Long estimateId,
+            @RequestBody String chatContent
+    ) {
+        EstimateChatSummaryResponse response = estimateUseCase.generateChatSummary(estimateId, chatContent);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -1,5 +1,6 @@
 package kr.co.isajjim.domains.estimate.presentation.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.co.isajjim.domains.estimate.application.request.*;
 import kr.co.isajjim.domains.estimate.application.response.EstimateChatSummaryResponse;
@@ -45,8 +46,10 @@ public class EstimateController implements EstimateApi {
     @Override
     @GetMapping(value = "/{estimateId}/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter getEstimateSSE(
-            @PathVariable Long estimateId
+            @PathVariable Long estimateId,
+            HttpServletResponse response
     ) {
+        response.setHeader("X-Accel-Buffering", "no");
         return estimateUseCase.subscribe(estimateId);
     }
 

--- a/src/main/java/kr/co/isajjim/global/config/llm/LlmConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/llm/LlmConfig.java
@@ -1,0 +1,14 @@
+package kr.co.isajjim.global.config.llm;
+
+import com.google.genai.Client;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LlmConfig {
+
+    @Bean
+    public Client geminiClient() {
+        return new Client();
+    }
+}

--- a/src/main/java/kr/co/isajjim/global/llm/LlmProvider.java
+++ b/src/main/java/kr/co/isajjim/global/llm/LlmProvider.java
@@ -1,0 +1,29 @@
+package kr.co.isajjim.global.llm;
+
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LlmProvider {
+
+    @Value("${infra.google.gemini.model}")
+    private String aiModel;
+
+    private final Client client;
+
+    public String llmCall(String prompt) {
+        try {
+            GenerateContentResponse response = client.models.generateContent(
+                    aiModel,
+                    prompt,
+                    null);
+            return response.text();
+        } catch (Exception e) {
+            throw new RuntimeException("AI 응답 생성 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,8 @@ infra:
     gcs:
       key-path: file:configs/gcsKey.json
       bucket: ${GOOGLE_GCS_BUCKET}
+    gemini:
+      model: ${GEMINI_MODEL}
 
 estimate:
   extra-volume-ratio: ${ESTIMATE_EXTRA_VOLUME_RATIO}


### PR DESCRIPTION
## 🚀 개요

- 업체와의 대화와 필수 기재 사항을 기반으로 최종 요약 견적서를 생성하는 API를 추가하였습니다.

## ✨ 작업 내용

- POST /api/v1/estimates/{estimateId}/chat-summary
```json
// Request
"대화 내용 전체"

// Response
{
  "code": "OK",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "summary": "**[이사 견적 확정 사항 요약]**\n\n*   **이사 일시**: 2026년 2월 3일..."
  }
}
```
- Cloud Run 인프라 환경에서 SSE 구독이 되지 않는 문제를 해결하였습니다. (bb72225)

## 🔧 앞으로의 과제

- 응답 템플릿 생성, Stream 적용