### PR TITLE
fix: CORS 에러 수정

### DIFF
--- a/src/main/java/kr/co/isajjim/global/config/security/SecurityConfig.java
+++ b/src/main/java/kr/co/isajjim/global/config/security/SecurityConfig.java
@@ -21,6 +21,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 import static kr.co.isajjim.global.common.Constants.WHITELIST;
 
@@ -45,6 +50,7 @@ public class SecurityConfig {
         http
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(session -> session
@@ -71,5 +77,23 @@ public class SecurityConfig {
                         .accessDeniedHandler(customAccessDeniedHandler));
 
         return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of(
+                "https://isajjim.kro.kr",
+                "https://dev.isajjim.kro.kr",
+                "http://localhost:3000",
+                "http://localhost:8081"
+        ));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
## 🚀 개요

- 프론트-백엔드 간 API 호출 시 발생하는 CORS 에러를 해결하였습니다.

## ✨ 작업 내용

- SecurityConfig에 cors 설정 추가
```diff
public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
  http
+  .cors(cors -> cors.configurationSource(corsConfigurationSource()))
...
}

+@Bean
+CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOriginPatterns(List.of(
+            "https://isajjim.kro.kr",
+            "https://dev.isajjim.kro.kr",
+            "http://localhost:3000",
+            "http://localhost:8081"
+    ));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowCredentials(true);
+    configuration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+}
```

## 💡 기술적 사항

- [티스토리 : 리액트<>스프링 부트 - 구글 로그인 CORS 에러 해결](https://hyotatofrappuccino.tistory.com/157)