### PR TITLE
refactor: AI Callback API에 인증 토큰 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,5 @@ MAIN_PAGE=/
 LOGIN_FAIL_PAGE=/
 LOCAL_URL=http://localhost:3000
 LOCAL_SECURE_URL=https://localhost:3000
+
+AUTH_TOKEN=

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/EstimateApi.java
@@ -21,10 +21,7 @@ import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Estimate", description = "견적서 API")
@@ -129,6 +126,7 @@ public interface EstimateApi {
             summary = "AI Callback API"
     )
     ResponseEntity<ApiResponse<Void>> aiCallback(
+            @RequestHeader("X-INTERNAL-TOKEN") String token,
             @PathVariable Long estimateId,
             @RequestBody AIAnalysisResponse request
     );

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -10,9 +10,11 @@ import kr.co.isajjim.domains.estimate.application.usecase.EstimateUseCase;
 import kr.co.isajjim.domains.estimate.presentation.api.EstimateApi;
 import kr.co.isajjim.global.common.ApiResponse;
 import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
 import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.infra.ai.application.dto.AIAnalysisResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +25,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/estimates")
 @RequiredArgsConstructor
 public class EstimateController implements EstimateApi {
+
+    @Value("${auth.internal-token}")
+    private String internalToken;
 
     private final EstimateUseCase estimateUseCase;
 
@@ -93,9 +98,11 @@ public class EstimateController implements EstimateApi {
     @Override
     @PostMapping("/{estimateId}/callback")
     public ResponseEntity<ApiResponse<Void>> aiCallback(
+            @RequestHeader("X-INTERNAL-TOKEN") String token,
             @PathVariable Long estimateId,
             @RequestBody AIAnalysisResponse request
     ) {
+        validateToken(token);
         estimateUseCase.saveFurnitureList(estimateId, request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
@@ -107,5 +114,12 @@ public class EstimateController implements EstimateApi {
     ) {
         EstimateChatSummaryResponse response = estimateUseCase.generateChatSummary(chatContent);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    // 추후 Filter 등으로 리팩토링 가능
+    private void validateToken(String token) {
+        if (!internalToken.equals(token)) {
+            throw new BaseException(ResponseCode.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/kr/co/isajjim/global/common/Constants.java
+++ b/src/main/java/kr/co/isajjim/global/common/Constants.java
@@ -16,6 +16,7 @@ public abstract class Constants {
 
     // whitelist
     public static final String[] WHITELIST = {
+            "/api/v1/estimates/*/callback",
             "/api/v1/users/reissue",
             "/login/**",
             "/oauth2/**",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,3 +81,6 @@ jwt:
 app:
   security:
     encryption-key: ${APP_ENCRYPTION_KEY}
+
+auth:
+  internal-token: ${AUTH_TOKEN}


### PR DESCRIPTION
## 🚀 개요

- Closes #35 
- AI Callback API 호출 시 인증을 요구하도록 인증 토큰을 추가하였습니다.

## ✨ 작업 내용

- WHITELIST에 `/api/v1/estimates/*/callback`을 추가하여 Security 인증 무시
- Callback API 헤더에 X-INTERNAL-TOKEN을 통해 인증 토큰을 전달하도록 요구

## 🔧 앞으로의 과제

- AI 서버 대응 사항 전달