### PR TITLE
fix: Cloudbuild 계정 오류 수정

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,3 +42,6 @@ steps:
             --restart unless-stopped \
             ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO_NAME}/${_IMAGE_NAME}:latest
         "
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## 🚀 개요

- 잘못된 Cloud Build 서비스 계정 구성 수정
- 빌드 로그를 버킷에 저장하지 않고, 콘솔 Log에서 보이도록 수정 

## ✨ 작업 내용

- 잘못된 Cloud Build 서비스 계정 구성 수정
- 빌드 로그를 버킷에 저장하지 않고, 콘솔 Log에서 보이도록 수정 

