### PR TITLE
🐛 fix: nginx 오류 수정

### DIFF
--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -1,11 +1,3 @@
-upstream spring-blue {
-    server spring-blue:8080;
-}
-
-upstream spring-green {
-    server spring-green:8080;
-}
-
 # HTTP -> HTTPS redirection
 server {
     listen 80;
@@ -26,13 +18,17 @@ server {
     include /etc/nginx/conf.d/service-url.inc;
     server_name NGINX_HOST;
 
+    # Docker 내부 DNS - upstream 블록 없이 동적 hostname 해석
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    set $service_port 8080;
+
     ssl_certificate /etc/letsencrypt/live/NGINX_HOST/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/NGINX_HOST/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location ~ ^/api/v1/(estimates/[0-9]+/sse)$ {
-        proxy_pass http://$service_url;
+        proxy_pass http://$service_url:$service_port;
 
         proxy_http_version 1.1;
         proxy_set_header Connection '';
@@ -48,7 +44,7 @@ server {
     }
 
     location / {
-        proxy_pass http://$service_url;
+        proxy_pass http://$service_url:$service_port;
 
         proxy_http_version 1.1;
         proxy_buffer_size 128k;

--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -50,13 +50,18 @@ server {
     location / {
         proxy_pass http://$service_url;
 
+        proxy_http_version 1.1;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_max_temp_file_size 0;
 
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 20m;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   spring-blue:
     image: ghcr.io/fittruck/isajjim-backend:dev
     container_name: spring-blue
+    depends_on:
+      redis:
+        condition: service_healthy
     ports:
       - "8080:8080"
     networks:
@@ -19,6 +22,9 @@ services:
   spring-green:
     image: ghcr.io/fittruck/isajjim-backend:dev
     container_name: spring-green
+    depends_on:
+      redis:
+        condition: service_healthy
     ports:
       - "8081:8080"
     networks:


### PR DESCRIPTION
## 🚀 개요

- 502 문제 수정
- websocket 연결 안되는 문제 수정

## ✨ 작업 내용

- blue-green 배포 중 nginx가 정지된 상태의 컨테이너 hostname을 정적 upstream 블록 reload 시점에 해석하지 못해 트래픽 전환 시 502 문제가 발생하던 문제 수정 (a401f450)
  - upstream spring-blue, upstream spring-green 정적 블록 제거
  - resolver 127.0.0.11 valid=10s ipv6=off 추가로 Docker 내부 DNS 동적 해석 활성화 => service-url.inc에서 컨테이너명을 받아와 동적 해석
- websocket 연결 안되는 문제 수정 : 연결 헤더 등 설정 (576f589f) [참고 자료](https://velog.io/@habins226/Nginx-WebSocket%EC%9D%84-%EC%9C%84%ED%95%9C-%EC%84%A4%EC%A0%95-%EB%B0%A9%EB%B2%95)
- 서버 배포 시 redis가 먼저 실행되어 있지 않으면 spring 서버가 실행되지 않아, redis healthcheck를 추가하여 정상 실행된 후 spring 컨테이너가 실행될 수 있도록 변경 (d334c973)