### PR TITLE
✨ feat: 앱 deeplink OAuth2 로그인 지원

### DIFF
--- a/src/main/java/kr/co/isajjim/global/security/component/OAuth2ResponseHandler.java
+++ b/src/main/java/kr/co/isajjim/global/security/component/OAuth2ResponseHandler.java
@@ -44,7 +44,17 @@ public class OAuth2ResponseHandler {
             }
             UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(redirectUri);
             queryParams.forEach(builder::queryParam);
-            response.sendRedirect(builder.build().toUriString());
+            String targetUrl = builder.build().toUriString();
+
+            // 커스텀 스킴 deeplink는 sendRedirect가 아닌 Location 헤더로 직접 처리
+            URI targetUri = URI.create(targetUrl);
+            String scheme = targetUri.getScheme();
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                response.setStatus(HttpServletResponse.SC_FOUND);
+                response.setHeader("Location", targetUrl);
+            } else {
+                response.sendRedirect(targetUrl);
+            }
         } else {
             writeJson(response, statusOnJson, jsonBody);
         }
@@ -52,9 +62,23 @@ public class OAuth2ResponseHandler {
 
     private boolean isAllowedRedirectUri(String redirectUri) {
         URI uri = URI.create(redirectUri);
-        String origin = uri.getScheme() + "://" + uri.getHost()
-                + (uri.getPort() == -1 ? "" : ":" + uri.getPort());
+        String scheme = uri.getScheme();
 
+        // 커스텀 스킴 deeplink는 스킴만 비교 (isajjim:// 등)
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            return oAuth2RedirectProperties.allowedRedirectUris().stream()
+                    .anyMatch(allowed -> {
+                        try {
+                            return scheme.equalsIgnoreCase(URI.create(allowed).getScheme());
+                        } catch (IllegalArgumentException e) {
+                            return false;
+                        }
+                    });
+        }
+
+        // 웹 URI는 origin(scheme+host+port)으로 비교
+        String origin = scheme + "://" + uri.getHost()
+                + (uri.getPort() == -1 ? "" : ":" + uri.getPort());
         return oAuth2RedirectProperties.allowedRedirectUris().stream()
                 .anyMatch(allowedUri -> allowedUri.equalsIgnoreCase(origin));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,6 +80,7 @@ oauth2:
     - http://localhost:8081
     - https://localhost:8081
     - https://isajjim.kro.kr
+    - isajjim://oauth2/callback
   client:
     provider:
       google:


### PR DESCRIPTION
## 🚀 개요

- 앱 환경에서 OAuth2 로그인 완료 후 deeplink로 리다이렉트되도록 지원

## ✨ 작업 내용

- `OAuth2ResponseHandler`: 커스텀 스킴(deeplink) URI 검증 로직 추가
 - 기존: http/https 기준 origin 비교만 지원
 - 변경: 비-HTTP 스킴은 scheme만 비교해 허용 여부 판단
- `OAuth2ResponseHandler`: deeplink 리다이렉트 시 `Location` 헤더 직접 설정 (302)
 - `response.sendRedirect()`는 커스텀 스킴 URI를 일부 컨테이너에서 처리 못함
- `application.yml`: `isajjim://oauth2/callback`을 허용 redirect URI 목록에 추가