### PR TITLE
🐛 fix: dev 프로파일 허용 redirect URI에 deeplink 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,3 +17,4 @@ oauth2:
   allowed-redirect-uris:
     - ${FRONTEND_URL}
     - ${DEV_BASE_URL}
+    - isajjim://oauth2/callback


### PR DESCRIPTION
## 🚀 개요

- `application-dev.yml`의 허용 redirect URI 목록에 앱 deeplink 스킴 누락 버그 수정

## ✨ 작업 내용

  - `application-dev.yml`의 `oauth2.allowed-redirect-uris`에 `isajjim://oauth2/callback` 추가
    - `application-dev.yml`이 `application.yml`의 해당 설정을 덮어쓰는 구조라 별도 추가 필요