### PR TITLE
🐛 fix: Nginx 프록시 환경에서 HTTPS scheme 인식되도록 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 # application.yml
+server:
+  forward-headers-strategy: native
+
 spring:
   application:
     name: isajjim


### PR DESCRIPTION
## 🚀 개요

- Nginx 리버스 프록시 환경에서 Spring이 HTTPS scheme을 인식하지 못해 OAuth2 redirect_uri가 http://로 생성되던 문제 수정

## ✨ 작업 내용

- `application.yml`에 `server.forward-headers-strategy: native` 추가
  - Spring이 Nginx의 `X-Forwarded-Proto: https` 헤더를 신뢰하도록 설정
  - 기존: redirect_uri = `http://api.isajjim.kro.kr/login/oauth2/code/naver`
  - 변경: redirect_uri = `https://api.isajjim.kro.kr/login/oauth2/code/naver`