### PR TITLE
✨ feat: 웹 로그인 이용약관 API 추가

### DIFF
--- a/src/main/java/kr/co/isajjim/global/security/api/AuthApi.java
+++ b/src/main/java/kr/co/isajjim/global/security/api/AuthApi.java
@@ -38,6 +38,31 @@ public interface AuthApi {
             @RequestBody @Valid SignUpRequest.Oidc request);
 
     @Operation(
+            summary = "이용약관 동의 여부 조회",
+            description = "로그인된 유저의 이용약관 동의 여부를 반환합니다. ACTIVE → true, PENDING → false"
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = Boolean.class,
+                    description = "이용약관 동의 여부 (true: 동의, false: 미동의)"
+            )
+    )
+    ResponseEntity<ApiResponse<Boolean>> getTermsAgreed(
+            @AuthenticationPrincipal CustomUserDetails user);
+
+    @Operation(
+            summary = "이용약관 동의 처리",
+            description = "PENDING 유저를 ACTIVE로 변경합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    description = "이용약관 동의 처리 성공"
+            )
+    )
+    ResponseEntity<ApiResponse<Void>> agreeTerms(
+            @AuthenticationPrincipal CustomUserDetails user);
+
+    @Operation(
             summary = "로그아웃",
             description = "(Nullable) refreshToken 전송 시 서버에서 폐기합니다."
     )

--- a/src/main/java/kr/co/isajjim/global/security/controller/AuthController.java
+++ b/src/main/java/kr/co/isajjim/global/security/controller/AuthController.java
@@ -35,6 +35,22 @@ public class AuthController implements AuthApi {
     }
 
     @Override
+    @GetMapping("/agree-terms")
+    public ResponseEntity<ApiResponse<Boolean>> getTermsAgreed(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        boolean agreed = oAuth2UseCase.getTermsAgreed(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, agreed));
+    }
+
+    @Override
+    @PostMapping("/agree-terms")
+    public ResponseEntity<ApiResponse<Void>> agreeTerms(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        oAuth2UseCase.agreeTerms(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+
+    @Override
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logOut(
             @RequestParam(required = false) String refreshToken,

--- a/src/main/java/kr/co/isajjim/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/kr/co/isajjim/global/security/service/CustomOAuth2UserService.java
@@ -67,8 +67,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 oAuth2Attributes.getEmail(),
                                 oAuth2Attributes.getProvider(),
                                 oAuth2Attributes.getProviderId(),
-                                // 웹 진입점 이용약관 동의 없이 즉시 회원가입
-                                UserStatus.ACTIVE
+                                UserStatus.PENDING
                         )
                 ));
     }

--- a/src/main/java/kr/co/isajjim/global/security/usecase/OAuth2UseCase.java
+++ b/src/main/java/kr/co/isajjim/global/security/usecase/OAuth2UseCase.java
@@ -102,6 +102,16 @@ public class OAuth2UseCase {
                 .build();
     }
 
+    public boolean getTermsAgreed(Long userId) {
+        UserEntity user = userService.getUserById(userId);
+        return user.getStatus() == UserStatus.ACTIVE;
+    }
+
+    @Transactional
+    public void agreeTerms(Long userId) {
+        userService.completeSignup(userId);
+    }
+
     @Transactional
     public void logOut(Long userId, String refreshToken) {
         jwtProvider.removeRefreshToken(userId, refreshToken);


### PR DESCRIPTION
## 🚀 개요

- 웹 OAuth2 로그인 후 이용약관 동의 여부를 확인/처리하는 API 추가

## ✨ 작업 내용

- `CustomOAuth2UserService.getOrSaveUser()`: 웹 OAuth2 신규 유저 저장 시 UserStatus ACTIVE → PENDING 변경
- `GET /api/v1/auth/agree-terms`: 로그인된 유저의 이용약관 동의 여부 반환 (ACTIVE → true, PENDING → false)
- `POST /api/v1/auth/agree-terms`: PENDING 유저를 ACTIVE로 변경 (이용약관 동의 처리)
- `AuthApi` 인터페이스에 두 API Swagger 명세 추가

## 💡 기술적 사항

- 모바일 `/auth/oauth/register` 플로우는 변경하지 않음
- JWT 필터는 UserStatus를 체크하지 않으므로 PENDING 유저도 `/agree-terms` 호출 가능
- `POST /agree-terms`는 멱등 — 이미 ACTIVE인 유저에게 재호출해도 오류 없음
- 기존 ACTIVE 유저는 `GET /agree-terms` 호출 시 즉시 `true` 반환 (하위 호환)
