### PR TITLE
✨ feat: 채팅 목록 실시간 업데이트를 위한 유저 레벨 구독 채널 추가

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/chat/application/dto/response/ChatRoomUpdateEvent.java
+++ b/src/main/java/kr/co/isajjim/domains/chat/application/dto/response/ChatRoomUpdateEvent.java
@@ -1,0 +1,21 @@
+package kr.co.isajjim.domains.chat.application.dto.response;
+
+import kr.co.isajjim.domains.chat.persistence.entity.ChatRoom;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomUpdateEvent(
+        Long roomId,
+        String lastMessageContent,
+        LocalDateTime lastMessageAt,
+        int unreadCount
+) {
+    public static ChatRoomUpdateEvent of(ChatRoom room, Long userId) {
+        return new ChatRoomUpdateEvent(
+                room.getId(),
+                room.getLastMessageContent(),
+                room.getLastMessageAt(),
+                room.getUnreadCountFor(userId)
+        );
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/chat/domain/service/ChatService.java
+++ b/src/main/java/kr/co/isajjim/domains/chat/domain/service/ChatService.java
@@ -2,6 +2,7 @@ package kr.co.isajjim.domains.chat.domain.service;
 
 import kr.co.isajjim.domains.chat.application.dto.request.ChatMessageRequest;
 import kr.co.isajjim.domains.chat.application.dto.response.ChatMessageResponse;
+import kr.co.isajjim.domains.chat.application.dto.response.ChatRoomUpdateEvent;
 import kr.co.isajjim.domains.chat.domain.constant.MessageType;
 import kr.co.isajjim.domains.chat.persistence.entity.ChatMessage;
 import kr.co.isajjim.domains.chat.persistence.entity.ChatRoom;
@@ -44,7 +45,12 @@ public class ChatService {
 
         ChatMessageResponse response = ChatMessageResponse.from(message);
         messagingTemplate.convertAndSend("/sub/chat/rooms/" + roomId, response);
-        fcmNotificationService.sendMessageNotification(room.getRecipientId(senderId), response);
+
+        Long recipientId = room.getRecipientId(senderId);
+        messagingTemplate.convertAndSend("/sub/user/" + senderId,   ChatRoomUpdateEvent.of(room, senderId));
+        messagingTemplate.convertAndSend("/sub/user/" + recipientId, ChatRoomUpdateEvent.of(room, recipientId));
+
+        fcmNotificationService.sendMessageNotification(recipientId, response);
     }
 
     @Transactional


### PR DESCRIPTION
## 🚀 개요

- 채팅 목록 화면에서 폴링 없이 실시간으로 마지막 메시지 및 안읽음 수를 갱신하기 위한 유저 레벨 WebSocket 구독 채널 추가

## ✨ 작업 내용

- ChatRoomUpdateEvent 응답 DTO 추가 (roomId, lastMessageContent, lastMessageAt, unreadCount)
- ChatService.sendMessage() 에서 메시지 발송 후 발신자·수신자 각각 /sub/user/{userId} 채널로 이벤트 발행
- 발신자는 unreadCount: 0, 수신자는 증가된 unreadCount 기준으로 각각 발행