### PR TITLE
♻️ refactor: AI Callback 헤더 이름 변경

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/EstimateController.java
@@ -98,7 +98,7 @@ public class EstimateController implements EstimateApi {
     @Override
     @PostMapping("/{estimateId}/callback")
     public ResponseEntity<ApiResponse<Void>> aiCallback(
-            @RequestHeader("X-INTERNAL-TOKEN") String token,
+            @RequestHeader("X_INTERNAL_TOKEN") String token,
             @PathVariable Long estimateId,
             @RequestBody AIAnalysisResponse request
     ) {


### PR DESCRIPTION
## 🚀 개요

- AI Callback 헤더를 `X-INTERNAL-TOKEN`에서 `X_INTERNAL_TOKEN`으로 변경하였습니다.
- 파이썬 AI 서버에서 -(대시)를 지원하지 않아 _(언더바)로 변경하였습니다.