### PR TITLE
✨ feat: 파트너 엔티티 및 API 구현

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/user/application/dto/request/RoleRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/dto/request/RoleRequest.java
@@ -1,0 +1,12 @@
+package kr.co.isajjim.domains.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+
+public record RoleRequest(
+        @NotNull
+        @Schema(description = "역할", example = "USER")
+        Role role
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/mapper/PartnerProfileMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/mapper/PartnerProfileMapper.java
@@ -1,0 +1,23 @@
+package kr.co.isajjim.domains.user.application.mapper;
+
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
+
+public class PartnerProfileMapper {
+
+    public static PartnerProfileResponse fromPartnerProfile(PartnerProfile partnerProfile) {
+        return PartnerProfileResponse.builder()
+                .id(partnerProfile.getId())
+                .userId(partnerProfile.getUser().getId())
+                .companyName(partnerProfile.getCompanyName())
+                .representativeName(partnerProfile.getRepresentativeName())
+                .businessRegistrationNumber(partnerProfile.getBusinessRegistrationNumber())
+                .businessAddress(partnerProfile.getBusinessAddress())
+                .contactPhone(partnerProfile.getContactPhone())
+                .introduction(partnerProfile.getIntroduction())
+                .businessRegistrationImageUrl(partnerProfile.getBusinessRegistrationImageUrl())
+                .approvalStatus(partnerProfile.getApprovalStatus())
+                .createdDate(partnerProfile.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApplicationRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApplicationRequest.java
@@ -1,0 +1,38 @@
+package kr.co.isajjim.domains.user.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.URL;
+
+public record PartnerApplicationRequest(
+        @Schema(description = "업체명", example = "이삿찜 이사")
+        @NotBlank
+        String companyName,
+
+        @Schema(description = "대표자명", example = "홍길동")
+        @NotBlank
+        String representativeName,
+
+        @Schema(description = "사업자등록번호", example = "123-45-67890")
+        @NotBlank
+        @Pattern(regexp = "\\d{3}-\\d{2}-\\d{5}", message = "사업자등록번호 형식이 올바르지 않습니다.")
+        String businessRegistrationNumber,
+
+        @Schema(description = "사업장 주소", example = "서울특별시 강남구 테헤란로 123")
+        @NotBlank
+        String businessAddress,
+
+        @Schema(description = "업체 연락처", example = "02-1234-5678")
+        @NotBlank
+        String contactPhone,
+
+        @Schema(description = "업체 소개", example = "이사 전문 업체입니다.")
+        String introduction,
+
+        @Schema(description = "사업자등록증 이미지 URL", example = "https://example.com/business-registration.jpg")
+        @NotBlank
+        @URL
+        String businessRegistrationImageUrl
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApprovalRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApprovalRequest.java
@@ -1,0 +1,12 @@
+package kr.co.isajjim.domains.user.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+
+public record PartnerApprovalRequest(
+        @Schema(description = "승인 처리 결과 (APPROVED 또는 REJECTED)", example = "APPROVED")
+        @NotNull
+        ApprovalStatus approvalStatus
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/response/PartnerProfileResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/response/PartnerProfileResponse.java
@@ -1,0 +1,44 @@
+package kr.co.isajjim.domains.user.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PartnerProfileResponse(
+        @Schema(description = "파트너 프로필 ID", example = "1")
+        Long id,
+
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "업체명", example = "이삿찜 이사")
+        String companyName,
+
+        @Schema(description = "대표자명", example = "홍길동")
+        String representativeName,
+
+        @Schema(description = "사업자등록번호", example = "123-45-67890")
+        String businessRegistrationNumber,
+
+        @Schema(description = "사업장 주소", example = "서울특별시 강남구 테헤란로 123")
+        String businessAddress,
+
+        @Schema(description = "업체 연락처", example = "02-1234-5678")
+        String contactPhone,
+
+        @Schema(description = "업체 소개", example = "이사 전문 업체입니다.")
+        String introduction,
+
+        @Schema(description = "사업자등록증 이미지 URL")
+        String businessRegistrationImageUrl,
+
+        @Schema(description = "승인 상태", example = "PENDING")
+        ApprovalStatus approvalStatus,
+
+        @Schema(description = "신청 일시")
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
@@ -1,0 +1,55 @@
+package kr.co.isajjim.domains.user.application.usecase;
+
+import kr.co.isajjim.domains.user.application.mapper.PartnerProfileMapper;
+import kr.co.isajjim.domains.user.application.request.PartnerApprovalRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.domain.service.PartnerProfileService;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
+import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPartnerUseCase {
+
+    private final PartnerProfileService partnerProfileService;
+    private final UserService userService;
+
+    public Page<PartnerProfileResponse> getList(ApprovalStatus approvalStatus, Pageable pageable) {
+        return partnerProfileService.getList(approvalStatus, pageable)
+                .map(PartnerProfileMapper::fromPartnerProfile);
+    }
+
+    @Transactional
+    public PartnerProfileResponse decide(Long partnerProfileId, PartnerApprovalRequest request) {
+        if (request.approvalStatus() == ApprovalStatus.PENDING) {
+            throw new BaseException(ResponseCode.INVALID_APPROVAL_STATUS);
+        }
+
+        PartnerProfile partnerProfile = partnerProfileService.getById(partnerProfileId);
+
+        if (request.approvalStatus() == ApprovalStatus.APPROVED) {
+            partnerProfileService.approve(partnerProfile);
+            userService.updateRole(partnerProfile.getUser(), Role.PARTNER);
+        } else {
+            partnerProfileService.reject(partnerProfile);
+        }
+
+        return PartnerProfileMapper.fromPartnerProfile(partnerProfile);
+    }
+
+    @Transactional
+    public void delete(Long partnerProfileId) {
+        PartnerProfile partnerProfile = partnerProfileService.getById(partnerProfileId);
+        partnerProfileService.delete(partnerProfile);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/PartnerApplicationUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/PartnerApplicationUseCase.java
@@ -1,0 +1,49 @@
+package kr.co.isajjim.domains.user.application.usecase;
+
+import kr.co.isajjim.domains.user.application.mapper.PartnerProfileMapper;
+import kr.co.isajjim.domains.user.application.request.PartnerApplicationRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.domain.service.PartnerProfileService;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartnerApplicationUseCase {
+
+    private final PartnerProfileService partnerProfileService;
+    private final UserService userService;
+
+    @Transactional
+    public PartnerProfileResponse apply(Long userId, PartnerApplicationRequest request) {
+        UserEntity user = userService.getUserById(userId);
+
+        if (partnerProfileService.existsByUserId(userId)) {
+            throw new BaseException(ResponseCode.DUPLICATE_PARTNER_APPLICATION);
+        }
+
+        PartnerProfile partnerProfile = partnerProfileService.create(user, request);
+        return PartnerProfileMapper.fromPartnerProfile(partnerProfile);
+    }
+
+    @Transactional
+    public PartnerProfileResponse update(Long userId, PartnerApplicationRequest request) {
+        PartnerProfile partnerProfile = partnerProfileService.getByUserId(userId);
+        partnerProfileService.update(partnerProfile, request);
+
+        return PartnerProfileMapper.fromPartnerProfile(partnerProfile);
+    }
+
+    @Transactional
+    public void cancel(Long userId) {
+        PartnerProfile partnerProfile = partnerProfileService.getByUserId(userId);
+        partnerProfileService.delete(partnerProfile);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
@@ -1,14 +1,19 @@
 package kr.co.isajjim.domains.user.application.usecase;
 
 import kr.co.isajjim.domains.user.application.dto.response.UserInfoResponse;
+import kr.co.isajjim.domains.user.domain.constant.Role;
 import kr.co.isajjim.domains.user.domain.service.UserService;
 import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
 import kr.co.isajjim.global.annotation.UseCase;
 import kr.co.isajjim.infra.s3.domain.service.S3Service;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserUseCase {
 
     private final UserService userService;
@@ -17,6 +22,18 @@ public class UserUseCase {
     public UserInfoResponse getMyInfo(Long userId) {
         UserEntity user = userService.getUserById(userId);
         return UserInfoResponse.from(user);
+    }
+
+    @Transactional
+    public void updateRole(Long userId, Role role) {
+        UserEntity user = userService.getUserById(userId);
+
+        // 어드민이 아닌 유저는 어드민으로 변경할 수 없음
+        if (user.getRole() != Role.ADMIN && role == Role.ADMIN) {
+            throw new BaseException(ResponseCode.FORBIDDEN);
+        }
+
+        userService.updateRole(user, role);
     }
 
     public void updateName(Long userId, String name) {
@@ -32,5 +49,6 @@ public class UserUseCase {
         if (imageUrl != null) {
             s3Service.deleteObjectByUrl(imageUrl);
         }
+        userService.updateRole(user, role);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
@@ -1,0 +1,30 @@
+package kr.co.isajjim.domains.user.application.usecase;
+
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserUseCase {
+
+    private final UserService userService;
+
+    @Transactional
+    public void updateRole(Long userId, Role role) {
+        UserEntity user = userService.getUserById(userId);
+
+        // 어드민이 아닌 유저는 어드민으로 변경할 수 없음
+        if (user.getRole() != Role.ADMIN && role == Role.ADMIN) {
+            throw new BaseException(ResponseCode.FORBIDDEN);
+        }
+
+        userService.updateRole(user, role);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/domain/constant/ApprovalStatus.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/constant/ApprovalStatus.java
@@ -1,0 +1,8 @@
+package kr.co.isajjim.domains.user.domain.constant;
+
+public enum ApprovalStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    ;
+}

--- a/src/main/java/kr/co/isajjim/domains/user/domain/constant/Role.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/constant/Role.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    // 필요에 따라 추가.
     USER("ROLE_USER", "사용자"),
+    PARTNER("ROLE_PARTNER", "파트너"),
     ADMIN("ROLE_ADMIN", "관리자"),
     ;
 

--- a/src/main/java/kr/co/isajjim/domains/user/domain/constant/Role.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/constant/Role.java
@@ -7,9 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    // 필요에 따라 추가.
     USER("ROLE_USER", "사용자"),
-    VENDOR("ROLE_VENDOR", "업체"),
+    PARTNER("ROLE_PARTNER", "파트너"),
     ADMIN("ROLE_ADMIN", "관리자"),
     ;
 

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
@@ -1,0 +1,89 @@
+package kr.co.isajjim.domains.user.domain.service;
+
+import kr.co.isajjim.domains.user.application.request.PartnerApplicationRequest;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.domains.user.persistence.repository.PartnerProfileRepository;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartnerProfileService {
+
+    private final PartnerProfileRepository partnerProfileRepository;
+
+    public PartnerProfile getById(Long partnerProfileId) {
+        return getOrThrow(partnerProfileId);
+    }
+
+    public PartnerProfile getByUserId(Long userId) {
+        return partnerProfileRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_PARTNER_PROFILE));
+    }
+
+    public boolean existsByUserId(Long userId) {
+        return partnerProfileRepository.existsByUser_Id(userId);
+    }
+
+    public Page<PartnerProfile> getList(ApprovalStatus approvalStatus, Pageable pageable) {
+        if (approvalStatus == null) {
+            return partnerProfileRepository.findAll(pageable);
+        }
+        return partnerProfileRepository.findAllByApprovalStatus(approvalStatus, pageable);
+    }
+
+    @Transactional
+    public PartnerProfile create(UserEntity user, PartnerApplicationRequest request) {
+        PartnerProfile partnerProfile = PartnerProfile.create(
+                user,
+                request.companyName(),
+                request.representativeName(),
+                request.businessRegistrationNumber(),
+                request.businessAddress(),
+                request.contactPhone(),
+                request.introduction(),
+                request.businessRegistrationImageUrl()
+        );
+        return partnerProfileRepository.save(partnerProfile);
+    }
+
+    @Transactional
+    public void update(PartnerProfile partnerProfile, PartnerApplicationRequest request) {
+        partnerProfile.updateProfile(
+                request.companyName(),
+                request.representativeName(),
+                request.businessRegistrationNumber(),
+                request.businessAddress(),
+                request.contactPhone(),
+                request.introduction(),
+                request.businessRegistrationImageUrl()
+        );
+    }
+
+    @Transactional
+    public void delete(PartnerProfile partnerProfile) {
+        partnerProfileRepository.delete(partnerProfile);
+    }
+
+    @Transactional
+    public void approve(PartnerProfile partnerProfile) {
+        partnerProfile.approve();
+    }
+
+    @Transactional
+    public void reject(PartnerProfile partnerProfile) {
+        partnerProfile.reject();
+    }
+
+    private PartnerProfile getOrThrow(Long id) {
+        return partnerProfileRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_PARTNER_PROFILE));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
@@ -1,5 +1,6 @@
 package kr.co.isajjim.domains.user.domain.service;
 
+import kr.co.isajjim.domains.user.domain.constant.Role;
 import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
 import kr.co.isajjim.domains.user.persistence.repository.UserRepository;
 import kr.co.isajjim.global.common.ResponseCode;
@@ -23,6 +24,10 @@ public class UserService {
         UserEntity user = getOrThrow(userId);
         user.updateSocialRefreshToken(token);
         userRepository.save(user); // Force update to ensure persistence
+    }
+
+    public void updateRole(UserEntity user, Role role) {
+        user.updateRole(role);
     }
 
     /* HELPER METHOD */

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/entity/PartnerProfile.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/entity/PartnerProfile.java
@@ -1,0 +1,98 @@
+package kr.co.isajjim.domains.user.persistence.entity;
+
+import jakarta.persistence.*;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.global.base.entity.BaseEntity;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(
+        name = "partner_profiles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_business_registration_number", columnNames = {"business_registration_number"})
+        }
+)
+@Builder(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartnerProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "partner_profile_id")
+    private Long id;
+
+    // 파트너(업체)로 전환한 유저 1명당 프로필 1개.
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private UserEntity user;
+
+    // 업체명
+    private String companyName;
+
+    // 대표자명
+    private String representativeName;
+
+    // 사업자등록번호
+    private String businessRegistrationNumber;
+
+    // 사업장 주소
+    private String businessAddress;
+
+    // 업체 연락처 (고객 문의용, 유저 계정의 소셜 정보와 별개)
+    private String contactPhone;
+
+    // 업체 소개
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    // 사업자등록증 사진 (S3 URL)
+    private String businessRegistrationImageUrl;
+
+    // 관리자 승인 여부. 승인 전까지는 파트너 권한이 있어도 노출/매칭에서 제외.
+    @Enumerated(EnumType.STRING)
+    private ApprovalStatus approvalStatus;
+
+    public static PartnerProfile create(UserEntity user, String companyName, String representativeName,
+                                         String businessRegistrationNumber, String businessAddress, String contactPhone,
+                                         String introduction, String businessRegistrationImageUrl) {
+        return PartnerProfile.builder()
+                .user(user)
+                .companyName(companyName)
+                .representativeName(representativeName)
+                .businessRegistrationNumber(businessRegistrationNumber)
+                .businessAddress(businessAddress)
+                .contactPhone(contactPhone)
+                .introduction(introduction)
+                .businessRegistrationImageUrl(businessRegistrationImageUrl)
+                .approvalStatus(ApprovalStatus.PENDING)
+                .build();
+    }
+
+    // 신청 정보 수정. 반려(REJECTED) 상태였던 신청을 수정하는 경우에만 재검토 대상이 되도록 PENDING으로 되돌린다.
+    // (APPROVED 상태는 role이 이미 PARTNER로 전환되어 이 메서드 자체가 호출되지 않음)
+    public void updateProfile(String companyName, String representativeName, String businessRegistrationNumber,
+                               String businessAddress, String contactPhone, String introduction,
+                               String businessRegistrationImageUrl) {
+        this.companyName = companyName;
+        this.representativeName = representativeName;
+        this.businessRegistrationNumber = businessRegistrationNumber;
+        this.businessAddress = businessAddress;
+        this.contactPhone = contactPhone;
+        this.introduction = introduction;
+        this.businessRegistrationImageUrl = businessRegistrationImageUrl;
+
+        if (this.approvalStatus == ApprovalStatus.REJECTED) {
+            this.approvalStatus = ApprovalStatus.PENDING;
+        }
+    }
+
+    public void approve() {
+        this.approvalStatus = ApprovalStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.approvalStatus = ApprovalStatus.REJECTED;
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/entity/UserEntity.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/entity/UserEntity.java
@@ -88,4 +88,8 @@ public class UserEntity extends BaseEntity {
     public void deleteProfileImage() {
         this.profileImageUrl = null;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/entity/UserEntity.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/entity/UserEntity.java
@@ -65,4 +65,8 @@ public class UserEntity extends BaseEntity {
     public void updateSocialRefreshToken(String socialRefreshToken) {
         this.socialRefreshToken = socialRefreshToken;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
@@ -1,0 +1,18 @@
+package kr.co.isajjim.domains.user.persistence.repository;
+
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PartnerProfileRepository extends JpaRepository<PartnerProfile, Long> {
+
+    Optional<PartnerProfile> findByUser_Id(Long userId);
+
+    boolean existsByUser_Id(Long userId);
+
+    Page<PartnerProfile> findAllByApprovalStatus(ApprovalStatus approvalStatus, Pageable pageable);
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
@@ -1,0 +1,81 @@
+package kr.co.isajjim.domains.user.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.request.PartnerApprovalRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Partner", description = "어드민 - 파트너 신청 관리 API")
+public interface AdminPartnerApi {
+
+    @Operation(
+            summary = "파트너 신청 목록 조회",
+            description = "파트너 신청 목록을 승인 상태(status)로 필터링하여 조회합니다. status를 생략하면 전체 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PartnerProfileResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<PartnerProfileResponse>>> getPartnerApplications(
+            @Parameter(in = ParameterIn.QUERY, description = "승인 상태 필터", example = "PENDING")
+            @RequestParam(required = false) ApprovalStatus status,
+            @Parameter(hidden = true) Pageable pageable
+    );
+
+    @Operation(
+            summary = "파트너 신청 승인/거부",
+            description = "파트너 신청을 승인하거나 거부합니다. 승인 시 대상 유저의 role이 PARTNER로 변경됩니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PartnerProfileResponse.class,
+                    description = "처리 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INVALID_APPROVAL_STATUS)
+            }
+    )
+    ResponseEntity<ApiResponse<PartnerProfileResponse>> decidePartnerApplication(
+            @PathVariable Long partnerProfileId,
+            @RequestBody @Valid PartnerApprovalRequest request
+    );
+
+    @Operation(
+            summary = "파트너 신청 삭제",
+            description = "파트너 신청 내역을 삭제합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(description = "삭제 성공"),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE)
+            }
+    )
+    ResponseEntity<ApiResponse<Void>> deletePartnerApplication(
+            @PathVariable Long partnerProfileId
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
@@ -1,0 +1,74 @@
+package kr.co.isajjim.domains.user.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.request.PartnerApplicationRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Partner Application", description = "파트너(업체) 신청 API")
+public interface PartnerApplicationApi {
+
+    @Operation(
+            summary = "파트너 신청",
+            description = "일반 유저가 파트너(업체) 전환을 신청합니다. 관리자 승인 전까지는 role이 변경되지 않습니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PartnerProfileResponse.class,
+                    description = "신청 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.DUPLICATE_PARTNER_APPLICATION)
+            }
+    )
+    ResponseEntity<ApiResponse<PartnerProfileResponse>> apply(
+            @RequestBody @Valid PartnerApplicationRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "파트너 신청 수정",
+            description = "본인의 파트너 신청 정보를 수정합니다. 반려된 신청을 수정하는 경우 승인 상태가 다시 PENDING으로 초기화됩니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PartnerProfileResponse.class,
+                    description = "수정 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE)
+            }
+    )
+    ResponseEntity<ApiResponse<PartnerProfileResponse>> update(
+            @RequestBody @Valid PartnerApplicationRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "파트너 신청 취소",
+            description = "본인의 파트너 신청을 취소(삭제)합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(description = "취소 성공"),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE)
+            }
+    )
+    ResponseEntity<ApiResponse<Void>> cancel(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
@@ -3,12 +3,15 @@ package kr.co.isajjim.domains.user.presentation.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.dto.request.RoleRequest;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
 import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.global.security.dto.ReissueRequest;
 import kr.co.isajjim.global.security.token.TokenResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User", description = "유저 API")
@@ -19,5 +22,13 @@ public interface UserApi {
     )
     @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(responseClass = TokenResponse.class, description = "재발급 성공"))
     ResponseEntity<ApiResponse<TokenResponse>> tokenReissue(
-            @RequestBody @Valid ReissueRequest request);
+            @RequestBody @Valid ReissueRequest request
+    );
+
+    @Operation(summary = "유저 본인 역할 변경", description = "USER/PARTNER 중 선택하여 변경")
+    @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(description = "변경 성공"))
+    ResponseEntity<ApiResponse<Void>> updateRole(
+            @RequestBody @Valid RoleRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
@@ -3,15 +3,12 @@ package kr.co.isajjim.domains.user.presentation.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import kr.co.isajjim.domains.user.application.dto.request.RoleRequest;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
 import kr.co.isajjim.global.common.ApiResponse;
-import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.global.security.dto.ReissueRequest;
 import kr.co.isajjim.global.security.token.TokenResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User", description = "유저 API")
@@ -23,12 +20,5 @@ public interface UserApi {
     @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(responseClass = TokenResponse.class, description = "재발급 성공"))
     ResponseEntity<ApiResponse<TokenResponse>> tokenReissue(
             @RequestBody @Valid ReissueRequest request
-    );
-
-    @Operation(summary = "유저 본인 역할 변경", description = "USER/PARTNER 중 선택하여 변경")
-    @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(description = "변경 성공"))
-    ResponseEntity<ApiResponse<Void>> updateRole(
-            @RequestBody @Valid RoleRequest request,
-            @AuthenticationPrincipal CustomUserDetails user
     );
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminPartnerController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminPartnerController.java
@@ -1,0 +1,54 @@
+package kr.co.isajjim.domains.user.presentation.controller;
+
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.request.PartnerApprovalRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.application.usecase.AdminPartnerUseCase;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.domains.user.presentation.api.AdminPartnerApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/partner-applications")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminPartnerController implements AdminPartnerApi {
+
+    private final AdminPartnerUseCase adminPartnerUseCase;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<PartnerProfileResponse>>> getPartnerApplications(
+            @RequestParam(required = false) ApprovalStatus status,
+            Pageable pageable
+    ) {
+        Page<PartnerProfileResponse> response = adminPartnerUseCase.getList(status, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @PatchMapping("/{partnerProfileId}")
+    public ResponseEntity<ApiResponse<PartnerProfileResponse>> decidePartnerApplication(
+            @PathVariable Long partnerProfileId,
+            @RequestBody @Valid PartnerApprovalRequest request
+    ) {
+        PartnerProfileResponse response = adminPartnerUseCase.decide(partnerProfileId, request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @DeleteMapping("/{partnerProfileId}")
+    public ResponseEntity<ApiResponse<Void>> deletePartnerApplication(
+            @PathVariable Long partnerProfileId
+    ) {
+        adminPartnerUseCase.delete(partnerProfileId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
@@ -1,0 +1,53 @@
+package kr.co.isajjim.domains.user.presentation.controller;
+
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.request.PartnerApplicationRequest;
+import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
+import kr.co.isajjim.domains.user.application.usecase.PartnerApplicationUseCase;
+import kr.co.isajjim.domains.user.presentation.api.PartnerApplicationApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/partner-applications")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+public class PartnerApplicationController implements PartnerApplicationApi {
+
+    private final PartnerApplicationUseCase partnerApplicationUseCase;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<PartnerProfileResponse>> apply(
+            @RequestBody @Valid PartnerApplicationRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        PartnerProfileResponse response = partnerApplicationUseCase.apply(user.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<PartnerProfileResponse>> update(
+            @RequestBody @Valid PartnerApplicationRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        PartnerProfileResponse response = partnerApplicationUseCase.update(user.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> cancel(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        partnerApplicationUseCase.cancel(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
@@ -1,24 +1,26 @@
 package kr.co.isajjim.domains.user.presentation.controller;
 
 import jakarta.validation.Valid;
+import kr.co.isajjim.domains.user.application.dto.request.RoleRequest;
+import kr.co.isajjim.domains.user.application.usecase.UserUseCase;
 import kr.co.isajjim.domains.user.presentation.api.UserApi;
 import kr.co.isajjim.global.common.ApiResponse;
 import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.global.security.dto.ReissueRequest;
 import kr.co.isajjim.global.security.token.JwtProvider;
 import kr.co.isajjim.global.security.token.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController implements UserApi {
 
+    private final UserUseCase userUseCase;
     private final JwtProvider jwtProvider;
 
     @Override
@@ -26,5 +28,15 @@ public class UserController implements UserApi {
     public ResponseEntity<ApiResponse<TokenResponse>> tokenReissue(@RequestBody @Valid ReissueRequest request) {
         TokenResponse tokenResponse = jwtProvider.reissueTokens(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, tokenResponse));
+    }
+
+    @Override
+    @PatchMapping("/role")
+    public ResponseEntity<ApiResponse<Void>> updateRole(
+            @RequestBody @Valid RoleRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        userUseCase.updateRole(user.getUserId(), request.role());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
@@ -1,18 +1,15 @@
 package kr.co.isajjim.domains.user.presentation.controller;
 
 import jakarta.validation.Valid;
-import kr.co.isajjim.domains.user.application.dto.request.RoleRequest;
 import kr.co.isajjim.domains.user.application.usecase.UserUseCase;
 import kr.co.isajjim.domains.user.presentation.api.UserApi;
 import kr.co.isajjim.global.common.ApiResponse;
 import kr.co.isajjim.global.common.ResponseCode;
-import kr.co.isajjim.global.security.auth.CustomUserDetails;
 import kr.co.isajjim.global.security.dto.ReissueRequest;
 import kr.co.isajjim.global.security.token.JwtProvider;
 import kr.co.isajjim.global.security.token.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,15 +25,5 @@ public class UserController implements UserApi {
     public ResponseEntity<ApiResponse<TokenResponse>> tokenReissue(@RequestBody @Valid ReissueRequest request) {
         TokenResponse tokenResponse = jwtProvider.reissueTokens(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, tokenResponse));
-    }
-
-    @Override
-    @PatchMapping("/role")
-    public ResponseEntity<ApiResponse<Void>> updateRole(
-            @RequestBody @Valid RoleRequest request,
-            @AuthenticationPrincipal CustomUserDetails user
-    ) {
-        userUseCase.updateRole(user.getUserId(), request.role());
-        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 }

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -51,6 +51,12 @@ public enum ResponseCode {
 
     /*    Image    */
     NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "IMAGE-001", "요청 이미지 ID를 찾을 수 없습니다."),
+
+
+    /*    Partner    */
+    NOT_FOUND_PARTNER_PROFILE(HttpStatus.NOT_FOUND, "PARTNER-001", "요청 파트너 신청 정보를 찾을 수 없습니다."),
+    DUPLICATE_PARTNER_APPLICATION(HttpStatus.BAD_REQUEST, "PARTNER-002", "이미 파트너 신청 내역이 존재합니다."),
+    INVALID_APPROVAL_STATUS(HttpStatus.BAD_REQUEST, "PARTNER-003", "승인 처리 값은 APPROVED 또는 REJECTED만 가능합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -58,6 +58,12 @@ public enum ResponseCode {
 
     /*    Image    */
     NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "IMAGE-001", "요청 이미지 ID를 찾을 수 없습니다."),
+
+
+    /*    Partner    */
+    NOT_FOUND_PARTNER_PROFILE(HttpStatus.NOT_FOUND, "PARTNER-001", "요청 파트너 신청 정보를 찾을 수 없습니다."),
+    DUPLICATE_PARTNER_APPLICATION(HttpStatus.BAD_REQUEST, "PARTNER-002", "이미 파트너 신청 내역이 존재합니다."),
+    INVALID_APPROVAL_STATUS(HttpStatus.BAD_REQUEST, "PARTNER-003", "승인 처리 값은 APPROVED 또는 REJECTED만 가능합니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🚀 개요

- 파트너 기본 엔티티 및 신청 API 구현

## ✨ 작업 내용

- 파트너 신청/관리 API 구현
  - 파트너 신청 : POST /api/v1/partner-applications
  - 파트너 신청 수정 : PATCH /api/v1/partner-applications/me
  - 파트너 신청 취소 : DELETE /api/v1/partner-applications/me 
  - (ADMIN) 파트너 신청 목록 조회 : GET /api/v1/admin/partner-applications
  - (ADMIN) 파트너 신청 승인/거부 : PATCH /api/v1/admin/partner-applications/{partnerProfileId}
  - (ADMIN) 파트너 신청 삭제 : DELETE /api/v1/admin/partner-applications/{partnerProfileId}