### PR TITLE
✨  feat: 어드민 페이지 구현

### DIFF
--- a/src/main/java/kr/co/isajjim/domains/chat/domain/service/FcmNotificationService.java
+++ b/src/main/java/kr/co/isajjim/domains/chat/domain/service/FcmNotificationService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -23,20 +24,25 @@ public class FcmNotificationService {
     private final UserService userService;
 
     public void sendMessageNotification(Long recipientId, ChatMessageResponse message) {
+        String senderName = userService.getUserById(message.senderId()).getName();
+        String body = message.type() == MessageType.IMAGE ? MessageType.IMAGE.label : message.content();
+
+        sendNotification(recipientId, senderName, body, Map.of("roomId", String.valueOf(message.roomId())));
+    }
+
+    public void sendNotification(Long recipientId, String title, String body, Map<String, String> data) {
         List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(recipientId);
         if (deviceTokens.isEmpty()) return;
 
         List<String> tokens = deviceTokens.stream().map(DeviceToken::getToken).toList();
-        String senderName = userService.getUserById(message.senderId()).getName();
-        String body = message.type() == MessageType.IMAGE ? MessageType.IMAGE.label : message.content();
 
         MulticastMessage fcmMessage = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(Notification.builder()
-                        .setTitle(senderName)
+                        .setTitle(title)
                         .setBody(body)
                         .build())
-                .putData("roomId", String.valueOf(message.roomId()))
+                .putAllData(data)
                 .build();
 
         try {

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/mapper/EstimateMapper.java
@@ -1,5 +1,6 @@
 package kr.co.isajjim.domains.estimate.application.mapper;
 
+import kr.co.isajjim.domains.estimate.application.response.AdminEstimateResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailListResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
 import kr.co.isajjim.domains.estimate.application.response.EstimateItemListResponse;
@@ -79,5 +80,22 @@ public class EstimateMapper {
             List<EstimateDetailResponse> items
     ) {
         return EstimateDetailListResponse.toEstimateDetailListResponse(items);
+    }
+
+    public static AdminEstimateResponse fromEstimateForAdmin(
+            Estimate estimate
+    ) {
+        UserEntity user = estimate.getUser();
+
+        return AdminEstimateResponse.builder()
+                .estimateId(estimate.getId())
+                .userId(user.getId())
+                .userName(user.getName())
+                .userEmail(user.getEmail())
+                .aiStatus(estimate.getAiStatus())
+                .preferredMovingDate(estimate.getPreferredMovingDate())
+                .createdDate(estimate.getCreatedDate())
+                .updatedAt(estimate.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/response/AdminEstimateResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/response/AdminEstimateResponse.java
@@ -1,0 +1,36 @@
+package kr.co.isajjim.domains.estimate.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record AdminEstimateResponse(
+        @Schema(description = "견적서 ID", example = "1")
+        Long estimateId,
+
+        @Schema(description = "신청자 유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "신청자 이름", example = "홍길동")
+        String userName,
+
+        @Schema(description = "신청자 이메일", example = "user@example.com")
+        String userEmail,
+
+        @Schema(description = "AI 처리 상태", example = "PENDING")
+        AIStatus aiStatus,
+
+        @Schema(description = "이사 희망 날짜")
+        LocalDate preferredMovingDate,
+
+        @Schema(description = "신청 일시")
+        LocalDateTime createdDate,
+
+        @Schema(description = "최종 수정 일시")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/AdminEstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/AdminEstimateUseCase.java
@@ -1,0 +1,31 @@
+package kr.co.isajjim.domains.estimate.application.usecase;
+
+import kr.co.isajjim.domains.estimate.application.mapper.EstimateMapper;
+import kr.co.isajjim.domains.estimate.application.response.AdminEstimateResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import kr.co.isajjim.domains.estimate.domain.service.EstimateService;
+import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
+import kr.co.isajjim.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminEstimateUseCase {
+
+    private final EstimateService estimateService;
+
+    public Page<AdminEstimateResponse> getList(AIStatus status, Pageable pageable) {
+        return estimateService.getList(status, pageable)
+                .map(EstimateMapper::fromEstimateForAdmin);
+    }
+
+    public EstimateDetailResponse getDetail(Long estimateId) {
+        Estimate estimate = estimateService.getEstimateById(estimateId);
+        return EstimateMapper.fromEstimate(estimate);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/AdminEstimateUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/application/usecase/AdminEstimateUseCase.java
@@ -19,8 +19,8 @@ public class AdminEstimateUseCase {
 
     private final EstimateService estimateService;
 
-    public Page<AdminEstimateResponse> getList(AIStatus status, Pageable pageable) {
-        return estimateService.getList(status, pageable)
+    public Page<AdminEstimateResponse> getList(AIStatus status, String keyword, Pageable pageable) {
+        return estimateService.getList(status, keyword, pageable)
                 .map(EstimateMapper::fromEstimateForAdmin);
     }
 

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -17,6 +17,8 @@ import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
 import kr.co.isajjim.global.llm.LlmProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,13 @@ public class EstimateService {
 
     public List<Estimate> getEstimatesByUserId(Long userId) {
         return estimateRepository.findAllByUserId(userId);
+    }
+
+    public Page<Estimate> getList(AIStatus status, Pageable pageable) {
+        if (status == null) {
+            return estimateRepository.findAll(pageable);
+        }
+        return estimateRepository.findAllByAiStatus(status, pageable);
     }
 
     public Long createEstimate(EstimateRequest request, UserEntity user) {

--- a/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/domain/service/EstimateService.java
@@ -40,11 +40,12 @@ public class EstimateService {
         return estimateRepository.findAllByUserId(userId);
     }
 
-    public Page<Estimate> getList(AIStatus status, Pageable pageable) {
-        if (status == null) {
-            return estimateRepository.findAll(pageable);
-        }
-        return estimateRepository.findAllByAiStatus(status, pageable);
+    public Page<Estimate> getList(AIStatus status, String keyword, Pageable pageable) {
+        return estimateRepository.search(status, normalizeKeyword(keyword), pageable);
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return (keyword == null || keyword.isBlank()) ? null : keyword.trim();
     }
 
     public Long createEstimate(EstimateRequest request, UserEntity user) {

--- a/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EstimateRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EstimateRepository.java
@@ -5,6 +5,8 @@ import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,5 +14,17 @@ public interface EstimateRepository extends JpaRepository<Estimate, Long> {
 
     List<Estimate> findAllByUserId(Long userId);
 
-    Page<Estimate> findAllByAiStatus(AIStatus aiStatus, Pageable pageable);
+    @Query("""
+            SELECT e FROM Estimate e
+            JOIN e.user u
+            WHERE (:aiStatus IS NULL OR e.aiStatus = :aiStatus)
+            AND (:keyword IS NULL
+                OR u.name LIKE CONCAT('%', :keyword, '%')
+                OR u.email LIKE CONCAT('%', :keyword, '%'))
+            """)
+    Page<Estimate> search(
+            @Param("aiStatus") AIStatus aiStatus,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EstimateRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/persistence/repository/EstimateRepository.java
@@ -1,6 +1,9 @@
 package kr.co.isajjim.domains.estimate.persistence.repository;
 
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
 import kr.co.isajjim.domains.estimate.persistence.entity.Estimate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +11,6 @@ import java.util.List;
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
 
     List<Estimate> findAllByUserId(Long userId);
+
+    Page<Estimate> findAllByAiStatus(AIStatus aiStatus, Pageable pageable);
 }

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/AdminEstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/AdminEstimateApi.java
@@ -1,0 +1,62 @@
+package kr.co.isajjim.domains.estimate.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.isajjim.domains.estimate.application.response.AdminEstimateResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Estimate", description = "어드민 - 견적서 관리 API")
+public interface AdminEstimateApi {
+
+    @Operation(
+            summary = "견적서 목록 조회",
+            description = "전체 견적서 목록을 AI 처리 상태(aiStatus)로 필터링하여 조회합니다. aiStatus를 생략하면 전체 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = AdminEstimateResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<AdminEstimateResponse>>> getEstimates(
+            @Parameter(in = ParameterIn.QUERY, description = "AI 처리 상태 필터", example = "FAILED")
+            @RequestParam(required = false) AIStatus aiStatus,
+            @Parameter(hidden = true) Pageable pageable
+    );
+
+    @Operation(
+            summary = "견적서 상세 조회",
+            description = "견적서 ID로 상세 정보(위치, 이미지, 견적 항목 포함)를 조회합니다. 소유자 검증 없이 모든 견적서를 조회할 수 있습니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = EstimateDetailResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_ESTIMATE)
+            }
+    )
+    ResponseEntity<ApiResponse<EstimateDetailResponse>> getEstimate(
+            @PathVariable Long estimateId
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/AdminEstimateApi.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/api/AdminEstimateApi.java
@@ -24,7 +24,7 @@ public interface AdminEstimateApi {
 
     @Operation(
             summary = "견적서 목록 조회",
-            description = "전체 견적서 목록을 AI 처리 상태(aiStatus)로 필터링하여 조회합니다. aiStatus를 생략하면 전체 조회합니다."
+            description = "전체 견적서 목록을 AI 처리 상태(aiStatus)로 필터링하고, 신청자 이름/이메일 키워드(keyword)로 검색하여 조회합니다. 둘 다 생략하면 전체 조회합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
@@ -39,6 +39,8 @@ public interface AdminEstimateApi {
     ResponseEntity<ApiResponse<Page<AdminEstimateResponse>>> getEstimates(
             @Parameter(in = ParameterIn.QUERY, description = "AI 처리 상태 필터", example = "FAILED")
             @RequestParam(required = false) AIStatus aiStatus,
+            @Parameter(in = ParameterIn.QUERY, description = "신청자 이름/이메일 검색 키워드", example = "홍길동")
+            @RequestParam(required = false) String keyword,
             @Parameter(hidden = true) Pageable pageable
     );
 

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/AdminEstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/AdminEstimateController.java
@@ -1,0 +1,47 @@
+package kr.co.isajjim.domains.estimate.presentation.controller;
+
+import kr.co.isajjim.domains.estimate.application.response.AdminEstimateResponse;
+import kr.co.isajjim.domains.estimate.application.response.EstimateDetailResponse;
+import kr.co.isajjim.domains.estimate.application.usecase.AdminEstimateUseCase;
+import kr.co.isajjim.domains.estimate.domain.constant.AIStatus;
+import kr.co.isajjim.domains.estimate.presentation.api.AdminEstimateApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/estimates")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminEstimateController implements AdminEstimateApi {
+
+    private final AdminEstimateUseCase adminEstimateUseCase;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<AdminEstimateResponse>>> getEstimates(
+            @RequestParam(required = false) AIStatus aiStatus,
+            Pageable pageable
+    ) {
+        Page<AdminEstimateResponse> response = adminEstimateUseCase.getList(aiStatus, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/{estimateId}")
+    public ResponseEntity<ApiResponse<EstimateDetailResponse>> getEstimate(
+            @PathVariable Long estimateId
+    ) {
+        EstimateDetailResponse response = adminEstimateUseCase.getDetail(estimateId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/AdminEstimateController.java
+++ b/src/main/java/kr/co/isajjim/domains/estimate/presentation/controller/AdminEstimateController.java
@@ -30,9 +30,10 @@ public class AdminEstimateController implements AdminEstimateApi {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<AdminEstimateResponse>>> getEstimates(
             @RequestParam(required = false) AIStatus aiStatus,
+            @RequestParam(required = false) String keyword,
             Pageable pageable
     ) {
-        Page<AdminEstimateResponse> response = adminEstimateUseCase.getList(aiStatus, pageable);
+        Page<AdminEstimateResponse> response = adminEstimateUseCase.getList(aiStatus, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 

--- a/src/main/java/kr/co/isajjim/domains/user/application/dto/response/RoleResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/dto/response/RoleResponse.java
@@ -1,0 +1,14 @@
+package kr.co.isajjim.domains.user.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+
+public record RoleResponse(
+        @Schema(description = "역할", example = "USER")
+        Role role
+) {
+    public static RoleResponse from(UserEntity user) {
+        return new RoleResponse(user.getRole());
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/listener/PartnerApprovalEventListener.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/listener/PartnerApprovalEventListener.java
@@ -1,0 +1,38 @@
+package kr.co.isajjim.domains.user.application.listener;
+
+import kr.co.isajjim.domains.chat.domain.service.FcmNotificationService;
+import kr.co.isajjim.domains.user.domain.event.PartnerApprovalDecidedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class PartnerApprovalEventListener {
+
+    private static final String TITLE = "파트너 신청 결과 안내";
+    private static final String APPROVED_BODY = "파트너 신청이 승인되었습니다.";
+
+    private final FcmNotificationService fcmNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePartnerApprovalDecided(PartnerApprovalDecidedEvent event) {
+        String body = switch (event.approvalStatus()) {
+            case APPROVED -> APPROVED_BODY;
+            case REJECTED -> "파트너 신청이 반려되었습니다. 사유: " + event.rejectionReason();
+            case PENDING -> throw new IllegalStateException("PENDING 상태는 알림 대상이 아닙니다.");
+        };
+
+        fcmNotificationService.sendNotification(
+                event.userId(),
+                TITLE,
+                body,
+                Map.of("approvalStatus", event.approvalStatus().name())
+        );
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/mapper/PartnerProfileMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/mapper/PartnerProfileMapper.java
@@ -17,6 +17,7 @@ public class PartnerProfileMapper {
                 .introduction(partnerProfile.getIntroduction())
                 .businessRegistrationImageUrl(partnerProfile.getBusinessRegistrationImageUrl())
                 .approvalStatus(partnerProfile.getApprovalStatus())
+                .rejectionReason(partnerProfile.getRejectionReason())
                 .createdDate(partnerProfile.getCreatedDate())
                 .build();
     }

--- a/src/main/java/kr/co/isajjim/domains/user/application/mapper/UserMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/mapper/UserMapper.java
@@ -1,0 +1,20 @@
+package kr.co.isajjim.domains.user.application.mapper;
+
+import kr.co.isajjim.domains.user.application.response.UserResponse;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+
+public class UserMapper {
+
+    public static UserResponse fromUser(UserEntity user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .socialProvider(user.getSocialProvider())
+                .status(user.getStatus())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdDate(user.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApprovalRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/request/PartnerApprovalRequest.java
@@ -7,6 +7,9 @@ import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
 public record PartnerApprovalRequest(
         @Schema(description = "승인 처리 결과 (APPROVED 또는 REJECTED)", example = "APPROVED")
         @NotNull
-        ApprovalStatus approvalStatus
+        ApprovalStatus approvalStatus,
+
+        @Schema(description = "반려 사유 (approvalStatus가 REJECTED인 경우 필수)", example = "사업자등록증 이미지가 확인되지 않습니다.")
+        String rejectionReason
 ) {
 }

--- a/src/main/java/kr/co/isajjim/domains/user/application/response/PartnerProfileResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/response/PartnerProfileResponse.java
@@ -38,6 +38,9 @@ public record PartnerProfileResponse(
         @Schema(description = "승인 상태", example = "PENDING")
         ApprovalStatus approvalStatus,
 
+        @Schema(description = "반려 사유 (approvalStatus가 REJECTED인 경우에만 값 존재)", example = "사업자등록증 이미지가 확인되지 않습니다.")
+        String rejectionReason,
+
         @Schema(description = "신청 일시")
         LocalDateTime createdDate
 ) {

--- a/src/main/java/kr/co/isajjim/domains/user/application/response/UserResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/response/UserResponse.java
@@ -1,0 +1,37 @@
+package kr.co.isajjim.domains.user.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.domain.constant.UserStatus;
+import kr.co.isajjim.global.security.constant.SocialProvider;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserResponse(
+        @Schema(description = "유저 ID", example = "1")
+        Long id,
+
+        @Schema(description = "이름", example = "홍길동")
+        String name,
+
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "역할", example = "USER")
+        Role role,
+
+        @Schema(description = "소셜 로그인 제공자", example = "KAKAO")
+        SocialProvider socialProvider,
+
+        @Schema(description = "계정 상태", example = "ACTIVE")
+        UserStatus status,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(description = "가입일시")
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
@@ -5,6 +5,7 @@ import kr.co.isajjim.domains.user.application.request.PartnerApprovalRequest;
 import kr.co.isajjim.domains.user.application.response.PartnerProfileResponse;
 import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
 import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.domain.event.PartnerApprovalDecidedEvent;
 import kr.co.isajjim.domains.user.domain.service.PartnerProfileService;
 import kr.co.isajjim.domains.user.domain.service.UserService;
 import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
@@ -12,6 +13,7 @@ import kr.co.isajjim.global.annotation.UseCase;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +25,7 @@ public class AdminPartnerUseCase {
 
     private final PartnerProfileService partnerProfileService;
     private final UserService userService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public Page<PartnerProfileResponse> getList(ApprovalStatus approvalStatus, Pageable pageable) {
         return partnerProfileService.getList(approvalStatus, pageable)
@@ -46,6 +49,12 @@ public class AdminPartnerUseCase {
             }
             partnerProfileService.reject(partnerProfile, request.rejectionReason());
         }
+
+        eventPublisher.publishEvent(new PartnerApprovalDecidedEvent(
+                partnerProfile.getUser().getId(),
+                request.approvalStatus(),
+                request.rejectionReason()
+        ));
 
         return PartnerProfileMapper.fromPartnerProfile(partnerProfile);
     }

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
@@ -50,6 +50,9 @@ public class AdminPartnerUseCase {
     @Transactional
     public void delete(Long partnerProfileId) {
         PartnerProfile partnerProfile = partnerProfileService.getById(partnerProfileId);
+        if (partnerProfile.getApprovalStatus() == ApprovalStatus.APPROVED) {
+            userService.updateRole(partnerProfile.getUser(), Role.USER);
+        }
         partnerProfileService.delete(partnerProfile);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
@@ -27,8 +27,8 @@ public class AdminPartnerUseCase {
     private final UserService userService;
     private final ApplicationEventPublisher eventPublisher;
 
-    public Page<PartnerProfileResponse> getList(ApprovalStatus approvalStatus, Pageable pageable) {
-        return partnerProfileService.getList(approvalStatus, pageable)
+    public Page<PartnerProfileResponse> getList(ApprovalStatus approvalStatus, String keyword, Pageable pageable) {
+        return partnerProfileService.getList(approvalStatus, keyword, pageable)
                 .map(PartnerProfileMapper::fromPartnerProfile);
     }
 

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminPartnerUseCase.java
@@ -41,7 +41,10 @@ public class AdminPartnerUseCase {
             partnerProfileService.approve(partnerProfile);
             userService.updateRole(partnerProfile.getUser(), Role.PARTNER);
         } else {
-            partnerProfileService.reject(partnerProfile);
+            if (request.rejectionReason() == null || request.rejectionReason().isBlank()) {
+                throw new BaseException(ResponseCode.REQUIRED_REJECTION_REASON);
+            }
+            partnerProfileService.reject(partnerProfile, request.rejectionReason());
         }
 
         return PartnerProfileMapper.fromPartnerProfile(partnerProfile);

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminUserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminUserUseCase.java
@@ -17,8 +17,8 @@ public class AdminUserUseCase {
 
     private final UserService userService;
 
-    public Page<UserResponse> getList(Role role, Pageable pageable) {
-        return userService.getList(role, pageable)
+    public Page<UserResponse> getList(Role role, String keyword, Pageable pageable) {
+        return userService.getList(role, keyword, pageable)
                 .map(UserMapper::fromUser);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminUserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/AdminUserUseCase.java
@@ -1,0 +1,24 @@
+package kr.co.isajjim.domains.user.application.usecase;
+
+import kr.co.isajjim.domains.user.application.mapper.UserMapper;
+import kr.co.isajjim.domains.user.application.response.UserResponse;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserUseCase {
+
+    private final UserService userService;
+
+    public Page<UserResponse> getList(Role role, Pageable pageable) {
+        return userService.getList(role, pageable)
+                .map(UserMapper::fromUser);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/PartnerApplicationUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/PartnerApplicationUseCase.java
@@ -21,6 +21,11 @@ public class PartnerApplicationUseCase {
     private final PartnerProfileService partnerProfileService;
     private final UserService userService;
 
+    public PartnerProfileResponse getMy(Long userId) {
+        PartnerProfile partnerProfile = partnerProfileService.getByUserId(userId);
+        return PartnerProfileMapper.fromPartnerProfile(partnerProfile);
+    }
+
     @Transactional
     public PartnerProfileResponse apply(Long userId, PartnerApplicationRequest request) {
         UserEntity user = userService.getUserById(userId);

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
@@ -1,5 +1,6 @@
 package kr.co.isajjim.domains.user.application.usecase;
 
+import kr.co.isajjim.domains.user.application.dto.response.RoleResponse;
 import kr.co.isajjim.domains.user.application.dto.response.UserInfoResponse;
 import kr.co.isajjim.domains.user.domain.constant.Role;
 import kr.co.isajjim.domains.user.domain.service.UserService;
@@ -22,6 +23,11 @@ public class UserUseCase {
     public UserInfoResponse getMyInfo(Long userId) {
         UserEntity user = userService.getUserById(userId);
         return UserInfoResponse.from(user);
+    }
+
+    public RoleResponse getMyRole(Long userId) {
+        UserEntity user = userService.getUserById(userId);
+        return RoleResponse.from(user);
     }
 
     @Transactional

--- a/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/user/application/usecase/UserUseCase.java
@@ -49,6 +49,5 @@ public class UserUseCase {
         if (imageUrl != null) {
             s3Service.deleteObjectByUrl(imageUrl);
         }
-        userService.updateRole(user, role);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/domain/event/PartnerApprovalDecidedEvent.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/event/PartnerApprovalDecidedEvent.java
@@ -1,0 +1,9 @@
+package kr.co.isajjim.domains.user.domain.event;
+
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+
+public record PartnerApprovalDecidedEvent(
+        Long userId,
+        ApprovalStatus approvalStatus,
+        String rejectionReason
+) {}

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
@@ -78,8 +78,8 @@ public class PartnerProfileService {
     }
 
     @Transactional
-    public void reject(PartnerProfile partnerProfile) {
-        partnerProfile.reject();
+    public void reject(PartnerProfile partnerProfile, String rejectionReason) {
+        partnerProfile.reject(rejectionReason);
     }
 
     private PartnerProfile getOrThrow(Long id) {

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
@@ -32,11 +32,12 @@ public class PartnerProfileService {
         return partnerProfileRepository.existsByUser_Id(userId);
     }
 
-    public Page<PartnerProfile> getList(ApprovalStatus approvalStatus, Pageable pageable) {
-        if (approvalStatus == null) {
-            return partnerProfileRepository.findAll(pageable);
-        }
-        return partnerProfileRepository.findAllByApprovalStatus(approvalStatus, pageable);
+    public Page<PartnerProfile> getList(ApprovalStatus approvalStatus, String keyword, Pageable pageable) {
+        return partnerProfileRepository.search(approvalStatus, normalizeKeyword(keyword), pageable);
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return (keyword == null || keyword.isBlank()) ? null : keyword.trim();
     }
 
     @Transactional

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
@@ -8,6 +8,8 @@ import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
 import kr.co.isajjim.global.security.constant.SocialProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,13 @@ public class UserService {
 
     public UserEntity getUserById(Long userId) {
         return getOrThrow(userId);
+    }
+
+    public Page<UserEntity> getList(Role role, Pageable pageable) {
+        if (role == null) {
+            return userRepository.findAll(pageable);
+        }
+        return userRepository.findAllByRole(role, pageable);
     }
 
     public Map<Long, UserEntity> getUserMapByIds(List<Long> userIds) {

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/UserService.java
@@ -28,11 +28,12 @@ public class UserService {
         return getOrThrow(userId);
     }
 
-    public Page<UserEntity> getList(Role role, Pageable pageable) {
-        if (role == null) {
-            return userRepository.findAll(pageable);
-        }
-        return userRepository.findAllByRole(role, pageable);
+    public Page<UserEntity> getList(Role role, String keyword, Pageable pageable) {
+        return userRepository.search(role, normalizeKeyword(keyword), pageable);
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return (keyword == null || keyword.isBlank()) ? null : keyword.trim();
     }
 
     public Map<Long, UserEntity> getUserMapByIds(List<Long> userIds) {

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/entity/PartnerProfile.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/entity/PartnerProfile.java
@@ -54,6 +54,10 @@ public class PartnerProfile extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ApprovalStatus approvalStatus;
 
+    // 반려 사유. REJECTED 상태일 때만 값이 존재.
+    @Column(columnDefinition = "TEXT")
+    private String rejectionReason;
+
     public static PartnerProfile create(UserEntity user, String companyName, String representativeName,
                                          String businessRegistrationNumber, String businessAddress, String contactPhone,
                                          String introduction, String businessRegistrationImageUrl) {
@@ -85,14 +89,17 @@ public class PartnerProfile extends BaseEntity {
 
         if (this.approvalStatus == ApprovalStatus.REJECTED) {
             this.approvalStatus = ApprovalStatus.PENDING;
+            this.rejectionReason = null;
         }
     }
 
     public void approve() {
         this.approvalStatus = ApprovalStatus.APPROVED;
+        this.rejectionReason = null;
     }
 
-    public void reject() {
+    public void reject(String rejectionReason) {
         this.approvalStatus = ApprovalStatus.REJECTED;
+        this.rejectionReason = rejectionReason;
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
@@ -5,6 +5,8 @@ import kr.co.isajjim.domains.user.persistence.entity.PartnerProfile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,5 +16,16 @@ public interface PartnerProfileRepository extends JpaRepository<PartnerProfile, 
 
     boolean existsByUser_Id(Long userId);
 
-    Page<PartnerProfile> findAllByApprovalStatus(ApprovalStatus approvalStatus, Pageable pageable);
+    @Query("""
+            SELECT p FROM PartnerProfile p
+            WHERE (:approvalStatus IS NULL OR p.approvalStatus = :approvalStatus)
+            AND (:keyword IS NULL
+                OR p.companyName LIKE CONCAT('%', :keyword, '%')
+                OR p.representativeName LIKE CONCAT('%', :keyword, '%'))
+            """)
+    Page<PartnerProfile> search(
+            @Param("approvalStatus") ApprovalStatus approvalStatus,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/repository/UserRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/repository/UserRepository.java
@@ -6,6 +6,8 @@ import kr.co.isajjim.global.security.constant.SocialProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,5 +15,16 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
 
-    Page<UserEntity> findAllByRole(Role role, Pageable pageable);
+    @Query("""
+            SELECT u FROM UserEntity u
+            WHERE (:role IS NULL OR u.role = :role)
+            AND (:keyword IS NULL
+                OR u.name LIKE CONCAT('%', :keyword, '%')
+                OR u.email LIKE CONCAT('%', :keyword, '%'))
+            """)
+    Page<UserEntity> search(
+            @Param("role") Role role,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/repository/UserRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package kr.co.isajjim.domains.user.persistence.repository;
 
+import kr.co.isajjim.domains.user.domain.constant.Role;
 import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
 import kr.co.isajjim.global.security.constant.SocialProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +12,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
+
+    Page<UserEntity> findAllByRole(Role role, Pageable pageable);
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
@@ -26,7 +26,7 @@ public interface AdminPartnerApi {
 
     @Operation(
             summary = "파트너 신청 목록 조회",
-            description = "파트너 신청 목록을 승인 상태(status)로 필터링하여 조회합니다. status를 생략하면 전체 조회합니다."
+            description = "파트너 신청 목록을 승인 상태(status)로 필터링하고, 업체명/대표자명 키워드(keyword)로 검색하여 조회합니다. 둘 다 생략하면 전체 조회합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
@@ -41,6 +41,8 @@ public interface AdminPartnerApi {
     ResponseEntity<ApiResponse<Page<PartnerProfileResponse>>> getPartnerApplications(
             @Parameter(in = ParameterIn.QUERY, description = "승인 상태 필터", example = "PENDING")
             @RequestParam(required = false) ApprovalStatus status,
+            @Parameter(in = ParameterIn.QUERY, description = "업체명/대표자명 검색 키워드", example = "이삿찜")
+            @RequestParam(required = false) String keyword,
             @Parameter(hidden = true) Pageable pageable
     );
 

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
@@ -66,7 +66,7 @@ public interface AdminPartnerApi {
 
     @Operation(
             summary = "파트너 신청 삭제",
-            description = "파트너 신청 내역을 삭제합니다."
+            description = "파트너 신청 내역을 삭제합니다. 이미 승인(APPROVED)된 파트너인 경우, 삭제와 함께 해당 유저의 role을 USER로 되돌립니다(파트너 권한 해제)."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(description = "삭제 성공"),

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminPartnerApi.java
@@ -46,7 +46,7 @@ public interface AdminPartnerApi {
 
     @Operation(
             summary = "파트너 신청 승인/거부",
-            description = "파트너 신청을 승인하거나 거부합니다. 승인 시 대상 유저의 role이 PARTNER로 변경됩니다."
+            description = "파트너 신청을 승인하거나 거부합니다. 승인 시 대상 유저의 role이 PARTNER로 변경됩니다. 거부(REJECTED) 시 rejectionReason은 필수입니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
@@ -56,7 +56,8 @@ public interface AdminPartnerApi {
             errors = {
                     @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
                     @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE),
-                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INVALID_APPROVAL_STATUS)
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INVALID_APPROVAL_STATUS),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.REQUIRED_REJECTION_REASON)
             }
     )
     ResponseEntity<ApiResponse<PartnerProfileResponse>> decidePartnerApplication(

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminUserApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminUserApi.java
@@ -22,7 +22,7 @@ public interface AdminUserApi {
 
     @Operation(
             summary = "유저 목록 조회",
-            description = "전체 유저 목록을 role로 필터링하여 조회합니다. role을 생략하면 전체 조회합니다."
+            description = "전체 유저 목록을 role로 필터링하고, 이름/이메일 키워드(keyword)로 검색하여 조회합니다. 둘 다 생략하면 전체 조회합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(
@@ -37,6 +37,8 @@ public interface AdminUserApi {
     ResponseEntity<ApiResponse<Page<UserResponse>>> getUsers(
             @Parameter(in = ParameterIn.QUERY, description = "역할 필터", example = "USER")
             @RequestParam(required = false) Role role,
+            @Parameter(in = ParameterIn.QUERY, description = "이름/이메일 검색 키워드", example = "홍길동")
+            @RequestParam(required = false) String keyword,
             @Parameter(hidden = true) Pageable pageable
     );
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminUserApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/AdminUserApi.java
@@ -1,0 +1,42 @@
+package kr.co.isajjim.domains.user.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.isajjim.domains.user.application.response.UserResponse;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin User", description = "어드민 - 유저 관리 API")
+public interface AdminUserApi {
+
+    @Operation(
+            summary = "유저 목록 조회",
+            description = "전체 유저 목록을 role로 필터링하여 조회합니다. role을 생략하면 전체 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = UserResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<UserResponse>>> getUsers(
+            @Parameter(in = ParameterIn.QUERY, description = "역할 필터", example = "USER")
+            @RequestParam(required = false) Role role,
+            @Parameter(hidden = true) Pageable pageable
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
@@ -20,6 +20,24 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface PartnerApplicationApi {
 
     @Operation(
+            summary = "내 파트너 신청 조회",
+            description = "본인의 파트너 신청 현황(승인 상태 등)을 조회합니다. 신청 전이라면 새로 신청하고, 신청 후라면 수정/취소할 수 있습니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = PartnerProfileResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_PARTNER_PROFILE)
+            }
+    )
+    ResponseEntity<ApiResponse<PartnerProfileResponse>> getMy(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
             summary = "파트너 신청",
             description = "일반 유저가 파트너(업체) 전환을 신청합니다. 관리자 승인 전까지는 role이 변경되지 않습니다."
     )

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/PartnerApplicationApi.java
@@ -21,7 +21,7 @@ public interface PartnerApplicationApi {
 
     @Operation(
             summary = "내 파트너 신청 조회",
-            description = "본인의 파트너 신청 현황(승인 상태 등)을 조회합니다. 신청 전이라면 새로 신청하고, 신청 후라면 수정/취소할 수 있습니다."
+            description = "본인의 파트너 신청 현황(승인 상태 등)을 조회합니다. 신청 전이라면 새로 신청하고, 신청 후라면 수정/취소할 수 있습니다. 승인되어 PARTNER role로 전환된 유저도 조회 가능합니다."
     )
     @ApiResponseExplanations(
             success = @ApiSuccessResponseExplanation(

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/api/UserApi.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import kr.co.isajjim.domains.chat.application.dto.request.DeviceTokenRequest;
 import kr.co.isajjim.domains.user.application.dto.request.ProfileImageRequest;
 import kr.co.isajjim.domains.user.application.dto.request.UpdateNameRequest;
+import kr.co.isajjim.domains.user.application.dto.response.RoleResponse;
 import kr.co.isajjim.domains.user.application.dto.response.UserInfoResponse;
 import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
 import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
@@ -31,6 +32,11 @@ public interface UserApi {
     @Operation(summary = "내 정보 조회", description = "이름, 프로필 이미지 URL을 반환합니다.")
     @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(responseClass = UserInfoResponse.class, description = "조회 성공"))
     ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user);
+
+    @Operation(summary = "내 역할 조회", description = "현재 로그인한 유저의 role(USER/PARTNER/ADMIN)을 반환합니다.")
+    @ApiResponseExplanations(success = @ApiSuccessResponseExplanation(responseClass = RoleResponse.class, description = "조회 성공"))
+    ResponseEntity<ApiResponse<RoleResponse>> getMyRole(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user);
 
     @Operation(summary = "이름 수정")

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminPartnerController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminPartnerController.java
@@ -27,9 +27,10 @@ public class AdminPartnerController implements AdminPartnerApi {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<PartnerProfileResponse>>> getPartnerApplications(
             @RequestParam(required = false) ApprovalStatus status,
+            @RequestParam(required = false) String keyword,
             Pageable pageable
     ) {
-        Page<PartnerProfileResponse> response = adminPartnerUseCase.getList(status, pageable);
+        Page<PartnerProfileResponse> response = adminPartnerUseCase.getList(status, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminUserController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminUserController.java
@@ -1,0 +1,36 @@
+package kr.co.isajjim.domains.user.presentation.controller;
+
+import kr.co.isajjim.domains.user.application.response.UserResponse;
+import kr.co.isajjim.domains.user.application.usecase.AdminUserUseCase;
+import kr.co.isajjim.domains.user.domain.constant.Role;
+import kr.co.isajjim.domains.user.presentation.api.AdminUserApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController implements AdminUserApi {
+
+    private final AdminUserUseCase adminUserUseCase;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<UserResponse>>> getUsers(
+            @RequestParam(required = false) Role role,
+            Pageable pageable
+    ) {
+        Page<UserResponse> response = adminUserUseCase.getList(role, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminUserController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/AdminUserController.java
@@ -28,9 +28,10 @@ public class AdminUserController implements AdminUserApi {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<UserResponse>>> getUsers(
             @RequestParam(required = false) Role role,
+            @RequestParam(required = false) String keyword,
             Pageable pageable
     ) {
-        Page<UserResponse> response = adminUserUseCase.getList(role, pageable);
+        Page<UserResponse> response = adminUserUseCase.getList(role, keyword, pageable);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
@@ -23,6 +23,15 @@ public class PartnerApplicationController implements PartnerApplicationApi {
     private final PartnerApplicationUseCase partnerApplicationUseCase;
 
     @Override
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PartnerProfileResponse>> getMy(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        PartnerProfileResponse response = partnerApplicationUseCase.getMy(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
     @PostMapping
     public ResponseEntity<ApiResponse<PartnerProfileResponse>> apply(
             @RequestBody @Valid PartnerApplicationRequest request,

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/PartnerApplicationController.java
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/partner-applications")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('USER')")
 public class PartnerApplicationController implements PartnerApplicationApi {
 
     private final PartnerApplicationUseCase partnerApplicationUseCase;
 
     @Override
     @GetMapping("/me")
+    @PreAuthorize("hasAnyRole('USER', 'PARTNER')")
     public ResponseEntity<ApiResponse<PartnerProfileResponse>> getMy(
             @AuthenticationPrincipal CustomUserDetails user
     ) {
@@ -33,6 +33,7 @@ public class PartnerApplicationController implements PartnerApplicationApi {
 
     @Override
     @PostMapping
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<PartnerProfileResponse>> apply(
             @RequestBody @Valid PartnerApplicationRequest request,
             @AuthenticationPrincipal CustomUserDetails user
@@ -43,6 +44,7 @@ public class PartnerApplicationController implements PartnerApplicationApi {
 
     @Override
     @PatchMapping("/me")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<PartnerProfileResponse>> update(
             @RequestBody @Valid PartnerApplicationRequest request,
             @AuthenticationPrincipal CustomUserDetails user
@@ -53,6 +55,7 @@ public class PartnerApplicationController implements PartnerApplicationApi {
 
     @Override
     @DeleteMapping("/me")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<Void>> cancel(
             @AuthenticationPrincipal CustomUserDetails user
     ) {

--- a/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
+++ b/src/main/java/kr/co/isajjim/domains/user/presentation/controller/UserController.java
@@ -5,6 +5,7 @@ import kr.co.isajjim.domains.chat.application.dto.request.DeviceTokenRequest;
 import kr.co.isajjim.domains.chat.application.usecase.DeviceTokenUseCase;
 import kr.co.isajjim.domains.user.application.dto.request.ProfileImageRequest;
 import kr.co.isajjim.domains.user.application.dto.request.UpdateNameRequest;
+import kr.co.isajjim.domains.user.application.dto.response.RoleResponse;
 import kr.co.isajjim.domains.user.application.dto.response.UserInfoResponse;
 import kr.co.isajjim.domains.user.application.usecase.UserUseCase;
 import kr.co.isajjim.domains.user.presentation.api.UserApi;
@@ -47,6 +48,15 @@ public class UserController implements UserApi {
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         UserInfoResponse response = userUseCase.getMyInfo(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/role")
+    public ResponseEntity<ApiResponse<RoleResponse>> getMyRole(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        RoleResponse response = userUseCase.getMyRole(user.getUserId());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 

--- a/src/main/java/kr/co/isajjim/global/common/Constants.java
+++ b/src/main/java/kr/co/isajjim/global/common/Constants.java
@@ -28,5 +28,6 @@ public abstract class Constants {
             "/favicon.ico",
             "/swagger-ui/**",
             "/v3/api-docs/**",
+            "/admin/**",
     };
 }

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -64,6 +64,7 @@ public enum ResponseCode {
     NOT_FOUND_PARTNER_PROFILE(HttpStatus.NOT_FOUND, "PARTNER-001", "요청 파트너 신청 정보를 찾을 수 없습니다."),
     DUPLICATE_PARTNER_APPLICATION(HttpStatus.BAD_REQUEST, "PARTNER-002", "이미 파트너 신청 내역이 존재합니다."),
     INVALID_APPROVAL_STATUS(HttpStatus.BAD_REQUEST, "PARTNER-003", "승인 처리 값은 APPROVED 또는 REJECTED만 가능합니다."),
+    REQUIRED_REJECTION_REASON(HttpStatus.BAD_REQUEST, "PARTNER-004", "거부 처리 시 반려 사유는 필수입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/isajjim/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/isajjim/global/exception/GlobalExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-//import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,12 +34,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
     }
 
-//    @ExceptionHandler(AccessDeniedException.class)
-//    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
-//        log.error("AccessDeniedException: ", e);
-//        ResponseCode responseCode = ResponseCode.FORBIDDEN;
-//        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
-//    }
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+        log.warn("AuthorizationDeniedException: {}", e.getMessage());
+        ResponseCode responseCode = ResponseCode.FORBIDDEN;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {

--- a/src/main/java/kr/co/isajjim/infra/s3/domain/constant/S3Folder.java
+++ b/src/main/java/kr/co/isajjim/infra/s3/domain/constant/S3Folder.java
@@ -10,6 +10,7 @@ public enum S3Folder {
     PROFILE("profile"),
     ROOM("room"),
     CHAT("chat"),
+    BUSINESS_REGISTRATION("business-registration"),
     ;
 
     private final String path;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,7 @@ oauth2:
   allowed-redirect-uris:
     - http://localhost:8081
     - https://localhost:8081
+    - http://localhost:8080
     - https://isajjim.kro.kr
     - isajjim://oauth2/callback
   client:

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이삿찜 찜 — 파트너 신청 관리</title>
+    <style>
+        :root {
+            --bg: #f4f5f7;
+            --surface: #ffffff;
+            --border: #e3e5e9;
+            --text: #1a1d23;
+            --text-muted: #6b7280;
+            --text-faint: #9aa1ac;
+            --accent: #2f6feb;
+            --accent-hover: #2559c4;
+            --accent-soft: #eaf1ff;
+            --danger: #dc2626;
+            --danger-soft: #fdecec;
+            --success: #15803d;
+            --success-soft: #e7f7ec;
+            --warning: #b45309;
+            --warning-soft: #fef3e0;
+            --radius: 10px;
+            --shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 1px 3px rgba(16, 24, 40, 0.06);
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Pretendard, Roboto, Helvetica, Arial, sans-serif;
+            font-size: 14px;
+            background: var(--bg);
+            color: var(--text);
+            padding: 32px 20px 60px;
+            line-height: 1.5;
+        }
+        .container { max-width: 1180px; margin: 0 auto; }
+        .hidden { display: none !important; }
+
+        /* ── Header ── */
+        .page-header { margin-bottom: 24px; }
+        .page-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; display: flex; align-items: center; gap: 8px; }
+        .subtitle { color: var(--text-muted); font-size: 13px; margin-top: 4px; }
+
+        /* ── Layout ── */
+        .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 24px; box-shadow: var(--shadow); }
+
+        .app-shell { display: flex; gap: 20px; align-items: flex-start; }
+        .sidebar {
+            width: 208px; flex: none; background: var(--surface); border: 1px solid var(--border);
+            border-radius: var(--radius); box-shadow: var(--shadow); padding: 12px; display: flex; flex-direction: column; gap: 2px;
+        }
+        .sidebar-title { font-size: 11px; font-weight: 700; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.04em; padding: 8px 10px 6px; }
+        .nav-item {
+            display: block; width: 100%; text-align: left; background: transparent; border: 1px solid transparent;
+            border-radius: 7px; padding: 9px 10px; font-size: 13.5px; font-weight: 600; color: var(--text-muted);
+        }
+        .nav-item:hover { background: var(--bg); }
+        .nav-item.active { background: var(--accent-soft); color: var(--accent-hover); }
+        .sidebar-footer { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border); }
+        .sidebar-footer .btn-logout { width: 100%; }
+        .content { flex: 1; min-width: 0; }
+
+        @media (max-width: 720px) {
+            .app-shell { flex-direction: column; }
+            .sidebar { width: 100%; flex-direction: row; flex-wrap: wrap; }
+            .sidebar-footer { margin-top: 0; padding-top: 0; border-top: none; margin-left: auto; }
+        }
+
+        /* ── Login / Access Denied ── */
+        .login-card { max-width: 380px; margin: 64px auto; text-align: center; padding: 36px 28px; }
+        .login-card h2 { font-size: 17px; font-weight: 700; margin-bottom: 6px; }
+        .login-card p { color: var(--text-muted); font-size: 13px; margin-bottom: 24px; }
+        .login-buttons { display: flex; flex-direction: column; gap: 10px; }
+        .btn-login { display: block; padding: 11px; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 14px; transition: filter 0.15s ease; }
+        .btn-login:hover { filter: brightness(0.96); }
+        .btn-kakao  { background: #FEE500; color: #1a1d23; }
+        .btn-google { background: #fff; color: #1a1d23; border: 1px solid var(--border); }
+        .btn-naver  { background: #03C75A; color: #fff; }
+
+        /* ── Banners ── */
+        .banner { padding: 12px 16px; border-radius: 8px; font-size: 13px; margin-bottom: 16px; font-weight: 500; }
+        .banner.error     { background: var(--danger-soft); color: var(--danger); border: 1px solid #f6cccc; }
+        .banner.forbidden { background: var(--danger-soft); color: var(--danger); border: 1px solid #f6cccc; }
+        .banner.info      { background: var(--accent-soft); color: var(--accent-hover); border: 1px solid #cfe0fb; }
+
+        /* ── Buttons ── */
+        button, .btn {
+            padding: 7px 14px; border: 1px solid transparent; border-radius: 7px; cursor: pointer;
+            font-family: inherit; font-size: 13px; font-weight: 600; white-space: nowrap; transition: filter 0.15s ease, background 0.15s ease;
+        }
+        button:disabled { opacity: 0.4; cursor: not-allowed; }
+        button:not(:disabled):hover { filter: brightness(0.95); }
+        .btn-logout   { background: var(--surface); color: var(--text-muted); border-color: var(--border); }
+        .btn-approve  { background: var(--success-soft); color: var(--success); border-color: #cdeed9; }
+        .btn-reject   { background: var(--warning-soft); color: var(--warning); border-color: #f5deb0; }
+        .btn-delete   { background: var(--danger-soft); color: var(--danger); border-color: #f6cccc; }
+        .btn-detail   { background: var(--surface); border-color: var(--border); color: var(--text-muted); }
+        .btn-page     { background: var(--surface); border-color: var(--border); color: var(--text); }
+
+        /* ── Filters ── */
+        .filters { display: flex; gap: 12px; align-items: flex-end; margin-bottom: 20px; }
+        .filters label { display: block; color: var(--text-muted); font-size: 12px; font-weight: 600; margin-bottom: 5px; }
+        select {
+            padding: 7px 10px; background: var(--surface); border: 1px solid var(--border); color: var(--text);
+            border-radius: 7px; font-family: inherit; font-size: 13px;
+        }
+        select:focus { outline: 2px solid var(--accent-soft); outline-offset: 1px; }
+        select:disabled { opacity: 0.6; cursor: not-allowed; }
+
+        /* ── Loading ── */
+        .loading-indicator { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: 12.5px; padding-bottom: 8px; }
+        .spinner {
+            width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent);
+            border-radius: 50%; display: inline-block; animation: spin 0.6s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        /* ── Table ── */
+        table { width: 100%; border-collapse: collapse; font-size: 13px; }
+        thead th {
+            text-align: left; color: var(--text-muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.02em;
+            border-bottom: 1px solid var(--border); padding: 10px 8px; white-space: nowrap;
+        }
+        tbody td { padding: 12px 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
+        tbody tr:hover td { background: #fafbfc; }
+        tbody tr.detail-row td { background: #f7f8fa; color: var(--text-muted); font-size: 12.5px; }
+        tbody tr.detail-row td > div { padding: 2px 0; }
+        .status-badge { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 100px; display: inline-block; }
+        .status-badge.PENDING  { background: var(--warning-soft); color: var(--warning); }
+        .status-badge.APPROVED { background: var(--success-soft); color: var(--success); }
+        .status-badge.REJECTED { background: var(--danger-soft); color: var(--danger); }
+        .status-badge.ACTIVE   { background: var(--success-soft); color: var(--success); }
+        .role-badge { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 100px; display: inline-block; }
+        .role-badge.USER    { background: var(--accent-soft); color: var(--accent-hover); }
+        .role-badge.PARTNER { background: var(--success-soft); color: var(--success); }
+        .role-badge.ADMIN   { background: var(--danger-soft); color: var(--danger); }
+        .actions { display: flex; gap: 6px; flex-wrap: wrap; }
+        .empty-row td { text-align: center; color: var(--text-faint); padding: 40px; }
+
+        /* ── Pagination ── */
+        .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 18px; font-size: 12.5px; color: var(--text-muted); }
+        .pagination .controls { display: flex; gap: 8px; align-items: center; }
+    </style>
+</head>
+<body>
+  <div class="container">
+    <div class="page-header">
+        <h1>이삿찜 관리페이지</h1>
+        <p class="subtitle">파트너 신청 관리 · 파트너 관리 · 유저 관리</p>
+    </div>
+
+    <!-- ── Login ── -->
+    <div id="loginSection" class="card login-card hidden">
+        <h2>로그인이 필요합니다</h2>
+        <p>관리자 계정으로 로그인하세요.</p>
+        <div id="loginBanner"></div>
+        <div class="login-buttons">
+            <a class="btn-login btn-kakao"  href="#" onclick="return login('kakao')">카카오로 로그인</a>
+            <a class="btn-login btn-google" href="#" onclick="return login('google')">구글로 로그인</a>
+            <a class="btn-login btn-naver"  href="#" onclick="return login('naver')">네이버로 로그인</a>
+        </div>
+    </div>
+
+    <!-- ── Access Denied ── -->
+    <div id="accessDeniedSection" class="card login-card hidden">
+        <h2>접근 권한이 없습니다</h2>
+        <p>이 페이지는 관리자 계정만 이용할 수 있습니다.</p>
+        <button class="btn-logout" onclick="logout()">로그아웃</button>
+    </div>
+
+    <!-- ── Dashboard ── -->
+    <div id="dashboardSection" class="hidden">
+        <div class="app-shell">
+            <nav class="sidebar">
+                <div class="sidebar-title">관리 메뉴</div>
+                <button class="nav-item active" id="navApplications" onclick="switchView('applications')">파트너 신청 관리</button>
+                <button class="nav-item" id="navCompanies" onclick="switchView('companies')">파트너 관리</button>
+                <button class="nav-item" id="navUsers" onclick="switchView('users')">유저 관리</button>
+                <div class="sidebar-footer">
+                    <button class="btn-logout" onclick="logout()">로그아웃</button>
+                </div>
+            </nav>
+
+            <div class="content card">
+                <div id="forbiddenBanner" class="banner forbidden hidden">
+                    관리자 권한이 없습니다. 관리자 계정으로 다시 로그인해주세요.
+                </div>
+                <div id="errorBanner" class="banner error hidden"></div>
+
+                <!-- Applications Panel -->
+                <div id="applicationsPanel">
+                    <div class="filters">
+                        <div>
+                            <label>승인 상태</label>
+                            <select id="statusFilter" onchange="onFilterChange('applications')">
+                                <option value="">전체</option>
+                                <option value="PENDING" selected>대기</option>
+                                <option value="APPROVED">승인</option>
+                                <option value="REJECTED">거부</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="sizeFilter" onchange="onFilterChange('applications')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div id="loadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>업체명</th>
+                                <th>대표자</th>
+                                <th>사업자등록번호</th>
+                                <th>상태</th>
+                                <th>신청일</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="tableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="pageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="prevBtn" onclick="changePage('applications', -1)">이전</button>
+                            <button class="btn-page" id="nextBtn" onclick="changePage('applications', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Companies Panel -->
+                <div id="companiesPanel" class="hidden">
+                    <div class="filters">
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="companySizeFilter" onchange="onFilterChange('companies')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div id="companyLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>업체명</th>
+                                <th>대표자</th>
+                                <th>사업자등록번호</th>
+                                <th>상태</th>
+                                <th>승인일</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="companyTableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="companyPageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="companyPrevBtn" onclick="changePage('companies', -1)">이전</button>
+                            <button class="btn-page" id="companyNextBtn" onclick="changePage('companies', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Users Panel -->
+                <div id="usersPanel" class="hidden">
+                    <div class="filters">
+                        <div>
+                            <label>역할</label>
+                            <select id="roleFilter" onchange="onFilterChange('users')">
+                                <option value="">전체</option>
+                                <option value="USER">사용자</option>
+                                <option value="PARTNER">파트너</option>
+                                <option value="ADMIN">관리자</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="userSizeFilter" onchange="onFilterChange('users')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div id="userLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>이름</th>
+                                <th>이메일</th>
+                                <th>역할</th>
+                                <th>소셜</th>
+                                <th>상태</th>
+                                <th>가입일</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="userTableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="userPageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="userPrevBtn" onclick="changePage('users', -1)">이전</button>
+                            <button class="btn-page" id="userNextBtn" onclick="changePage('users', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+  </div>
+
+    <script>
+        const TOKEN_KEY = 'isajjim_admin_access_token';
+        const STATUS_LABEL = { PENDING: '대기', APPROVED: '승인', REJECTED: '거부' };
+        const ROLE_LABEL = { USER: '사용자', PARTNER: '파트너', ADMIN: '관리자' };
+        const USER_STATUS_LABEL = { PENDING: '이용약관 미동의', ACTIVE: '활성' };
+        const SOCIAL_LABEL = { KAKAO: '카카오', NAVER: '네이버', GOOGLE: '구글' };
+
+        const VIEWS = {
+            applications: {
+                endpoint: '/api/v1/admin/partner-applications',
+                filterParamName: 'status',
+                filterId: 'statusFilter',
+                fixedValue: null,
+                sizeFilterId: 'sizeFilter',
+                loadingId: 'loadingIndicator',
+                tableBodyId: 'tableBody',
+                pageInfoId: 'pageInfo',
+                prevBtnId: 'prevBtn',
+                nextBtnId: 'nextBtn',
+                emptyMessage: '신청 내역이 없습니다.',
+                colspan: 7,
+                state: { page: 0, totalPages: 0, expandedId: null, lastList: [] }
+            },
+            companies: {
+                endpoint: '/api/v1/admin/partner-applications',
+                filterParamName: 'status',
+                filterId: null,
+                fixedValue: 'APPROVED',
+                sizeFilterId: 'companySizeFilter',
+                loadingId: 'companyLoadingIndicator',
+                tableBodyId: 'companyTableBody',
+                pageInfoId: 'companyPageInfo',
+                prevBtnId: 'companyPrevBtn',
+                nextBtnId: 'companyNextBtn',
+                emptyMessage: '등록된 파트너가 없습니다.',
+                colspan: 7,
+                state: { page: 0, totalPages: 0, expandedId: null, lastList: [] }
+            },
+            users: {
+                endpoint: '/api/v1/admin/users',
+                filterParamName: 'role',
+                filterId: 'roleFilter',
+                fixedValue: null,
+                sizeFilterId: 'userSizeFilter',
+                loadingId: 'userLoadingIndicator',
+                tableBodyId: 'userTableBody',
+                pageInfoId: 'userPageInfo',
+                prevBtnId: 'userPrevBtn',
+                nextBtnId: 'userNextBtn',
+                emptyMessage: '등록된 유저가 없습니다.',
+                colspan: 8,
+                state: { page: 0, totalPages: 0, expandedId: null, lastList: [] }
+            }
+        };
+        let currentView = 'applications';
+
+        function getToken() { return localStorage.getItem(TOKEN_KEY); }
+        function setToken(t) { localStorage.setItem(TOKEN_KEY, t); }
+        function clearToken() { localStorage.removeItem(TOKEN_KEY); }
+
+        function login(provider) {
+            const redirectUri = window.location.origin + window.location.pathname;
+            window.location.href = `/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+            return false;
+        }
+
+        function logout() {
+            clearToken();
+            render();
+        }
+
+        function showLoginBanner(msg) {
+            const el = document.getElementById('loginBanner');
+            if (!msg) { el.innerHTML = ''; return; }
+            el.innerHTML = `<div class="banner error">${msg}</div>`;
+        }
+
+        function decodeJwtRole(token) {
+            try {
+                const payload = token.split('.')[1];
+                const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+                const json = decodeURIComponent(
+                    atob(base64).split('').map(c => '%' + c.charCodeAt(0).toString(16).padStart(2, '0')).join('')
+                );
+                return JSON.parse(json).role;
+            } catch (_) {
+                return null;
+            }
+        }
+
+        function render() {
+            const token = getToken();
+            document.getElementById('loginSection').classList.toggle('hidden', !!token);
+            document.getElementById('accessDeniedSection').classList.add('hidden');
+            document.getElementById('dashboardSection').classList.add('hidden');
+            if (!token) return;
+
+            const role = decodeJwtRole(token);
+            if (role === null) {
+                clearToken();
+                render();
+                showLoginBanner('유효하지 않은 토큰입니다. 다시 로그인해주세요.');
+                return;
+            }
+            if (role !== 'ROLE_ADMIN') {
+                document.getElementById('accessDeniedSection').classList.remove('hidden');
+                return;
+            }
+
+            document.getElementById('dashboardSection').classList.remove('hidden');
+            switchView(currentView);
+        }
+
+        function switchView(viewKey) {
+            currentView = viewKey;
+            document.getElementById('navApplications').classList.toggle('active', viewKey === 'applications');
+            document.getElementById('navCompanies').classList.toggle('active', viewKey === 'companies');
+            document.getElementById('navUsers').classList.toggle('active', viewKey === 'users');
+            document.getElementById('applicationsPanel').classList.toggle('hidden', viewKey !== 'applications');
+            document.getElementById('companiesPanel').classList.toggle('hidden', viewKey !== 'companies');
+            document.getElementById('usersPanel').classList.toggle('hidden', viewKey !== 'users');
+            document.getElementById('forbiddenBanner').classList.add('hidden');
+            document.getElementById('errorBanner').classList.add('hidden');
+            loadView(viewKey);
+        }
+
+        async function apiFetch(path, options = {}) {
+            const token = getToken();
+            const res = await fetch(path, {
+                ...options,
+                headers: {
+                    'Authorization': 'Bearer ' + token,
+                    'Content-Type': 'application/json',
+                    ...(options.headers || {})
+                }
+            });
+            let body = null;
+            try { body = await res.json(); } catch (_) {}
+            return { ok: res.ok, status: res.status, body };
+        }
+
+        function onFilterChange(viewKey) {
+            VIEWS[viewKey].state.page = 0;
+            loadView(viewKey);
+        }
+
+        function setLoading(viewKey, isLoading) {
+            const cfg = VIEWS[viewKey];
+            document.getElementById(cfg.loadingId).classList.toggle('hidden', !isLoading);
+            if (cfg.filterId) document.getElementById(cfg.filterId).disabled = isLoading;
+            document.getElementById(cfg.sizeFilterId).disabled = isLoading;
+        }
+
+        async function loadView(viewKey) {
+            const cfg = VIEWS[viewKey];
+            setLoading(viewKey, true);
+            try {
+                const size = document.getElementById(cfg.sizeFilterId).value;
+                const params = new URLSearchParams({ page: cfg.state.page, size, sort: 'createdDate,desc' });
+                const filterValue = cfg.fixedValue || (cfg.filterId && document.getElementById(cfg.filterId).value);
+                if (filterValue) params.set(cfg.filterParamName, filterValue);
+
+                const { ok, status: httpStatus, body } = await apiFetch(`${cfg.endpoint}?${params}`);
+
+                if (httpStatus === 403) {
+                    document.getElementById('forbiddenBanner').classList.remove('hidden');
+                    document.getElementById('errorBanner').classList.add('hidden');
+                    document.getElementById(cfg.tableBodyId).innerHTML = '';
+                    document.getElementById(cfg.pageInfoId).textContent = '—';
+                    return;
+                }
+                if (httpStatus === 401) {
+                    clearToken();
+                    render();
+                    showLoginBanner('로그인이 만료되었습니다. 다시 로그인해주세요.');
+                    return;
+                }
+                if (!ok) {
+                    document.getElementById('errorBanner').textContent = `오류: ${body?.message || httpStatus}`;
+                    document.getElementById('errorBanner').classList.remove('hidden');
+                    return;
+                }
+
+                document.getElementById('forbiddenBanner').classList.add('hidden');
+                document.getElementById('errorBanner').classList.add('hidden');
+
+                const page = body.data;
+                cfg.state.lastList = page.content;
+                cfg.state.totalPages = page.totalPages;
+                renderTable(viewKey, page.content);
+                document.getElementById(cfg.pageInfoId).textContent =
+                    `${page.totalElements}건 중 ${page.number + 1} / ${Math.max(page.totalPages, 1)} 페이지`;
+                document.getElementById(cfg.prevBtnId).disabled = page.first;
+                document.getElementById(cfg.nextBtnId).disabled = page.last;
+            } finally {
+                setLoading(viewKey, false);
+            }
+        }
+
+        function changePage(viewKey, delta) {
+            const cfg = VIEWS[viewKey];
+            const next = cfg.state.page + delta;
+            if (next < 0 || next >= cfg.state.totalPages) return;
+            cfg.state.page = next;
+            loadView(viewKey);
+        }
+
+        function renderTable(viewKey, list) {
+            if (viewKey === 'users') {
+                renderUserTable(list);
+                return;
+            }
+
+            const cfg = VIEWS[viewKey];
+            const tbody = document.getElementById(cfg.tableBodyId);
+            tbody.innerHTML = '';
+            if (!list.length) {
+                tbody.innerHTML = `<tr class="empty-row"><td colspan="${cfg.colspan}">${cfg.emptyMessage}</td></tr>`;
+                return;
+            }
+            list.forEach(p => {
+                const row = document.createElement('tr');
+                const actionsHtml = viewKey === 'companies'
+                    ? `
+                        <button class="btn-detail" onclick="toggleDetail('${viewKey}', ${p.id})">상세</button>
+                        <button class="btn-delete" onclick="revokeCompany(${p.id})">파트너 권한 해제</button>
+                    `
+                    : `
+                        <button class="btn-detail" onclick="toggleDetail('${viewKey}', ${p.id})">상세</button>
+                        <button class="btn-approve" ${p.approvalStatus === 'APPROVED' ? 'disabled' : ''} onclick="decide(${p.id}, 'APPROVED')">승인</button>
+                        <button class="btn-reject" ${p.approvalStatus === 'REJECTED' ? 'disabled' : ''} onclick="decide(${p.id}, 'REJECTED')">거부</button>
+                        <button class="btn-delete" onclick="removeApplication(${p.id})">삭제</button>
+                    `;
+                row.innerHTML = `
+                    <td>${p.id}</td>
+                    <td>${escapeHtml(p.companyName)}</td>
+                    <td>${escapeHtml(p.representativeName)}</td>
+                    <td>${escapeHtml(p.businessRegistrationNumber)}</td>
+                    <td><span class="status-badge ${p.approvalStatus}">${STATUS_LABEL[p.approvalStatus] || p.approvalStatus}</span></td>
+                    <td>${formatDate(p.createdDate)}</td>
+                    <td class="actions">${actionsHtml}</td>
+                `;
+                tbody.appendChild(row);
+
+                if (cfg.state.expandedId === p.id) {
+                    const detailRow = document.createElement('tr');
+                    detailRow.className = 'detail-row';
+                    detailRow.innerHTML = `
+                        <td colspan="${cfg.colspan}">
+                            <div>연락처: ${escapeHtml(p.contactPhone || '-')}</div>
+                            <div>사업장 주소: ${escapeHtml(p.businessAddress || '-')}</div>
+                            <div>소개: ${escapeHtml(p.introduction || '-')}</div>
+                            <div>사업자등록증: ${p.businessRegistrationImageUrl
+                                ? `<a href="${p.businessRegistrationImageUrl}" target="_blank" style="color:#2f6feb;">${p.businessRegistrationImageUrl}</a>`
+                                : '-'}</div>
+                            <div>유저 ID: ${p.userId}</div>
+                        </td>
+                    `;
+                    tbody.appendChild(detailRow);
+                }
+            });
+        }
+
+        function renderUserTable(list) {
+            const cfg = VIEWS.users;
+            const tbody = document.getElementById(cfg.tableBodyId);
+            tbody.innerHTML = '';
+            if (!list.length) {
+                tbody.innerHTML = `<tr class="empty-row"><td colspan="${cfg.colspan}">${cfg.emptyMessage}</td></tr>`;
+                return;
+            }
+            list.forEach(u => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${u.id}</td>
+                    <td>${escapeHtml(u.name)}</td>
+                    <td>${escapeHtml(u.email)}</td>
+                    <td><span class="role-badge ${u.role}">${ROLE_LABEL[u.role] || u.role}</span></td>
+                    <td>${SOCIAL_LABEL[u.socialProvider] || u.socialProvider}</td>
+                    <td><span class="status-badge ${u.status}">${USER_STATUS_LABEL[u.status] || u.status}</span></td>
+                    <td>${formatDate(u.createdDate)}</td>
+                    <td class="actions">
+                        <button class="btn-detail" onclick="toggleDetail('users', ${u.id})">상세</button>
+                    </td>
+                `;
+                tbody.appendChild(row);
+
+                if (cfg.state.expandedId === u.id) {
+                    const detailRow = document.createElement('tr');
+                    detailRow.className = 'detail-row';
+                    detailRow.innerHTML = `
+                        <td colspan="${cfg.colspan}">
+                            <div>프로필 이미지: ${u.profileImageUrl
+                                ? `<a href="${u.profileImageUrl}" target="_blank" style="color:#2f6feb;">${u.profileImageUrl}</a>`
+                                : '-'}</div>
+                        </td>
+                    `;
+                    tbody.appendChild(detailRow);
+                }
+            });
+        }
+
+        function toggleDetail(viewKey, id) {
+            const cfg = VIEWS[viewKey];
+            cfg.state.expandedId = cfg.state.expandedId === id ? null : id;
+            renderTable(viewKey, cfg.state.lastList);
+        }
+
+        async function decide(id, approvalStatus) {
+            const label = approvalStatus === 'APPROVED' ? '승인' : '거부';
+            if (!confirm(`이 신청을 ${label}하시겠습니까?`)) return;
+            const { ok, status, body } = await apiFetch(`/api/v1/admin/partner-applications/${id}`, {
+                method: 'PATCH',
+                body: JSON.stringify({ approvalStatus })
+            });
+            if (status === 403) { document.getElementById('forbiddenBanner').classList.remove('hidden'); return; }
+            if (!ok) { alert(`처리 실패: ${body?.message || status}`); return; }
+            loadView('applications');
+        }
+
+        async function removeApplication(id) {
+            if (!confirm('이 신청을 삭제하시겠습니까? 되돌릴 수 없습니다.')) return;
+            const { ok, status, body } = await apiFetch(`/api/v1/admin/partner-applications/${id}`, { method: 'DELETE' });
+            if (status === 403) { document.getElementById('forbiddenBanner').classList.remove('hidden'); return; }
+            if (!ok) { alert(`삭제 실패: ${body?.message || status}`); return; }
+            loadView('applications');
+        }
+
+        async function revokeCompany(id) {
+            if (!confirm('이 파트너의 권한을 해제하시겠습니까? 해당 유저는 일반 사용자로 전환되고, 신청 내역이 삭제됩니다.')) return;
+            const { ok, status, body } = await apiFetch(`/api/v1/admin/partner-applications/${id}`, { method: 'DELETE' });
+            if (status === 403) { document.getElementById('forbiddenBanner').classList.remove('hidden'); return; }
+            if (!ok) { alert(`처리 실패: ${body?.message || status}`); return; }
+            loadView('companies');
+        }
+
+        function formatDate(iso) {
+            if (!iso) return '-';
+            return iso.replace('T', ' ').slice(0, 16);
+        }
+
+        function escapeHtml(str) {
+            if (str == null) return '';
+            return String(str)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;');
+        }
+
+        function init() {
+            const params = new URLSearchParams(window.location.search);
+            const accessToken = params.get('accessToken');
+            const error = params.get('error');
+
+            if (accessToken) {
+                setToken(accessToken);
+                history.replaceState({}, '', window.location.pathname);
+            } else if (error) {
+                history.replaceState({}, '', window.location.pathname);
+                showLoginBanner(`로그인 실패: ${error}`);
+            }
+
+            render();
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -149,7 +149,6 @@
   <div class="container">
     <div class="page-header">
         <h1>이삿찜 관리페이지</h1>
-        <p class="subtitle">파트너 신청 관리 · 파트너 관리 · 유저 관리</p>
     </div>
 
     <!-- ── Login ── -->

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -98,14 +98,16 @@
         .btn-page     { background: var(--surface); border-color: var(--border); color: var(--text); }
 
         /* ── Filters ── */
-        .filters { display: flex; gap: 12px; align-items: flex-end; margin-bottom: 20px; }
-        .filters label { display: block; color: var(--text-muted); font-size: 12px; font-weight: 600; margin-bottom: 5px; }
-        select {
-            padding: 7px 10px; background: var(--surface); border: 1px solid var(--border); color: var(--text);
-            border-radius: 7px; font-family: inherit; font-size: 13px;
+        .filters { display: flex; gap: 12px; align-items: flex-end; margin-bottom: 20px; flex-wrap: wrap; }
+        .filters > div { display: flex; flex-direction: column; }
+        .filters label { display: block; color: var(--text-muted); font-size: 12px; font-weight: 600; margin-bottom: 5px; line-height: 1; }
+        select, input[type="text"] {
+            box-sizing: border-box; height: 34px; padding: 0 10px; background: var(--surface); border: 1px solid var(--border);
+            color: var(--text); border-radius: 7px; font-family: inherit; font-size: 13px; line-height: 32px;
         }
-        select:focus { outline: 2px solid var(--accent-soft); outline-offset: 1px; }
-        select:disabled { opacity: 0.6; cursor: not-allowed; }
+        input[type="text"] { width: 200px; }
+        select:focus, input[type="text"]:focus { outline: 2px solid var(--accent-soft); outline-offset: 1px; }
+        select:disabled, input[type="text"]:disabled { opacity: 0.6; cursor: not-allowed; }
 
         /* ── Loading ── */
         .loading-indicator { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: 12.5px; padding-bottom: 8px; }
@@ -210,6 +212,10 @@
                                 <option value="50">50</option>
                             </select>
                         </div>
+                        <div>
+                            <label>검색 (업체명/대표자명)</label>
+                            <input type="text" id="keywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('applications')">
+                        </div>
                         <div id="loadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
                     </div>
 
@@ -247,6 +253,10 @@
                                 <option value="20">20</option>
                                 <option value="50">50</option>
                             </select>
+                        </div>
+                        <div>
+                            <label>검색 (업체명/대표자명)</label>
+                            <input type="text" id="companyKeywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('companies')">
                         </div>
                         <div id="companyLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
                     </div>
@@ -294,6 +304,10 @@
                                 <option value="20">20</option>
                                 <option value="50">50</option>
                             </select>
+                        </div>
+                        <div>
+                            <label>검색 (이름/이메일)</label>
+                            <input type="text" id="userKeywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('users')">
                         </div>
                         <div id="userLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
                     </div>
@@ -344,6 +358,10 @@
                                 <option value="50">50</option>
                             </select>
                         </div>
+                        <div>
+                            <label>검색 (신청자 이름/이메일)</label>
+                            <input type="text" id="estimateKeywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('estimates')">
+                        </div>
                         <div id="estimateLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
                     </div>
 
@@ -388,6 +406,7 @@
                 filterParamName: 'status',
                 filterId: 'statusFilter',
                 fixedValue: null,
+                keywordFilterId: 'keywordFilter',
                 sizeFilterId: 'sizeFilter',
                 loadingId: 'loadingIndicator',
                 tableBodyId: 'tableBody',
@@ -403,6 +422,7 @@
                 filterParamName: 'status',
                 filterId: null,
                 fixedValue: 'APPROVED',
+                keywordFilterId: 'companyKeywordFilter',
                 sizeFilterId: 'companySizeFilter',
                 loadingId: 'companyLoadingIndicator',
                 tableBodyId: 'companyTableBody',
@@ -418,6 +438,7 @@
                 filterParamName: 'role',
                 filterId: 'roleFilter',
                 fixedValue: null,
+                keywordFilterId: 'userKeywordFilter',
                 sizeFilterId: 'userSizeFilter',
                 loadingId: 'userLoadingIndicator',
                 tableBodyId: 'userTableBody',
@@ -433,6 +454,7 @@
                 filterParamName: 'aiStatus',
                 filterId: 'estimateStatusFilter',
                 fixedValue: null,
+                keywordFilterId: 'estimateKeywordFilter',
                 sizeFilterId: 'estimateSizeFilter',
                 loadingId: 'estimateLoadingIndicator',
                 tableBodyId: 'estimateTableBody',
@@ -538,6 +560,16 @@
             loadView(viewKey);
         }
 
+        const keywordDebounceTimers = {};
+
+        function onKeywordInput(viewKey) {
+            clearTimeout(keywordDebounceTimers[viewKey]);
+            keywordDebounceTimers[viewKey] = setTimeout(() => {
+                VIEWS[viewKey].state.page = 0;
+                loadView(viewKey);
+            }, 400);
+        }
+
         function setLoading(viewKey, isLoading) {
             const cfg = VIEWS[viewKey];
             document.getElementById(cfg.loadingId).classList.toggle('hidden', !isLoading);
@@ -553,6 +585,8 @@
                 const params = new URLSearchParams({ page: cfg.state.page, size, sort: 'createdDate,desc' });
                 const filterValue = cfg.fixedValue || (cfg.filterId && document.getElementById(cfg.filterId).value);
                 if (filterValue) params.set(cfg.filterParamName, filterValue);
+                const keyword = cfg.keywordFilterId && document.getElementById(cfg.keywordFilterId).value.trim();
+                if (keyword) params.set('keyword', keyword);
 
                 const { ok, status: httpStatus, body } = await apiFetch(`${cfg.endpoint}?${params}`);
 

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -126,10 +126,13 @@
         tbody tr.detail-row td { background: #f7f8fa; color: var(--text-muted); font-size: 12.5px; }
         tbody tr.detail-row td > div { padding: 2px 0; }
         .status-badge { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 100px; display: inline-block; }
-        .status-badge.PENDING  { background: var(--warning-soft); color: var(--warning); }
-        .status-badge.APPROVED { background: var(--success-soft); color: var(--success); }
-        .status-badge.REJECTED { background: var(--danger-soft); color: var(--danger); }
-        .status-badge.ACTIVE   { background: var(--success-soft); color: var(--success); }
+        .status-badge.PENDING    { background: var(--warning-soft); color: var(--warning); }
+        .status-badge.APPROVED   { background: var(--success-soft); color: var(--success); }
+        .status-badge.REJECTED   { background: var(--danger-soft); color: var(--danger); }
+        .status-badge.ACTIVE     { background: var(--success-soft); color: var(--success); }
+        .status-badge.PROCESSING { background: var(--accent-soft); color: var(--accent-hover); }
+        .status-badge.COMPLETED  { background: var(--success-soft); color: var(--success); }
+        .status-badge.FAILED     { background: var(--danger-soft); color: var(--danger); }
         .role-badge { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 100px; display: inline-block; }
         .role-badge.USER    { background: var(--accent-soft); color: var(--accent-hover); }
         .role-badge.PARTNER { background: var(--success-soft); color: var(--success); }
@@ -176,6 +179,7 @@
                 <button class="nav-item active" id="navApplications" onclick="switchView('applications')">파트너 신청 관리</button>
                 <button class="nav-item" id="navCompanies" onclick="switchView('companies')">파트너 관리</button>
                 <button class="nav-item" id="navUsers" onclick="switchView('users')">유저 관리</button>
+                <button class="nav-item" id="navEstimates" onclick="switchView('estimates')">견적서 관리</button>
                 <div class="sidebar-footer">
                     <button class="btn-logout" onclick="logout()">로그아웃</button>
                 </div>
@@ -319,6 +323,53 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- Estimates Panel -->
+                <div id="estimatesPanel" class="hidden">
+                    <div class="filters">
+                        <div>
+                            <label>AI 처리 상태</label>
+                            <select id="estimateStatusFilter" onchange="onFilterChange('estimates')">
+                                <option value="">전체</option>
+                                <option value="PENDING">대기</option>
+                                <option value="PROCESSING">분석중</option>
+                                <option value="COMPLETED">완료</option>
+                                <option value="FAILED">실패</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="estimateSizeFilter" onchange="onFilterChange('estimates')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div id="estimateLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>신청자</th>
+                                <th>AI 상태</th>
+                                <th>이사 희망일</th>
+                                <th>신청일</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="estimateTableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="estimatePageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="estimatePrevBtn" onclick="changePage('estimates', -1)">이전</button>
+                            <button class="btn-page" id="estimateNextBtn" onclick="changePage('estimates', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -330,6 +381,7 @@
         const ROLE_LABEL = { USER: '사용자', PARTNER: '파트너', ADMIN: '관리자' };
         const USER_STATUS_LABEL = { PENDING: '이용약관 미동의', ACTIVE: '활성' };
         const SOCIAL_LABEL = { KAKAO: '카카오', NAVER: '네이버', GOOGLE: '구글' };
+        const AI_STATUS_LABEL = { PENDING: '대기', PROCESSING: '분석중', COMPLETED: '완료', FAILED: '실패' };
 
         const VIEWS = {
             applications: {
@@ -376,6 +428,21 @@
                 emptyMessage: '등록된 유저가 없습니다.',
                 colspan: 8,
                 state: { page: 0, totalPages: 0, expandedId: null, lastList: [] }
+            },
+            estimates: {
+                endpoint: '/api/v1/admin/estimates',
+                filterParamName: 'aiStatus',
+                filterId: 'estimateStatusFilter',
+                fixedValue: null,
+                sizeFilterId: 'estimateSizeFilter',
+                loadingId: 'estimateLoadingIndicator',
+                tableBodyId: 'estimateTableBody',
+                pageInfoId: 'estimatePageInfo',
+                prevBtnId: 'estimatePrevBtn',
+                nextBtnId: 'estimateNextBtn',
+                emptyMessage: '견적서가 없습니다.',
+                colspan: 6,
+                state: { page: 0, totalPages: 0, expandedId: null, lastList: [], detailCache: {} }
             }
         };
         let currentView = 'applications';
@@ -442,9 +509,11 @@
             document.getElementById('navApplications').classList.toggle('active', viewKey === 'applications');
             document.getElementById('navCompanies').classList.toggle('active', viewKey === 'companies');
             document.getElementById('navUsers').classList.toggle('active', viewKey === 'users');
+            document.getElementById('navEstimates').classList.toggle('active', viewKey === 'estimates');
             document.getElementById('applicationsPanel').classList.toggle('hidden', viewKey !== 'applications');
             document.getElementById('companiesPanel').classList.toggle('hidden', viewKey !== 'companies');
             document.getElementById('usersPanel').classList.toggle('hidden', viewKey !== 'users');
+            document.getElementById('estimatesPanel').classList.toggle('hidden', viewKey !== 'estimates');
             document.getElementById('forbiddenBanner').classList.add('hidden');
             document.getElementById('errorBanner').classList.add('hidden');
             loadView(viewKey);
@@ -536,6 +605,10 @@
                 renderUserTable(list);
                 return;
             }
+            if (viewKey === 'estimates') {
+                renderEstimateTable(list);
+                return;
+            }
 
             const cfg = VIEWS[viewKey];
             const tbody = document.getElementById(cfg.tableBodyId);
@@ -625,6 +698,78 @@
                     tbody.appendChild(detailRow);
                 }
             });
+        }
+
+        function renderEstimateTable(list) {
+            const cfg = VIEWS.estimates;
+            const tbody = document.getElementById(cfg.tableBodyId);
+            tbody.innerHTML = '';
+            if (!list.length) {
+                tbody.innerHTML = `<tr class="empty-row"><td colspan="${cfg.colspan}">${cfg.emptyMessage}</td></tr>`;
+                return;
+            }
+            list.forEach(e => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${e.estimateId}</td>
+                    <td>${escapeHtml(e.userName)} (${escapeHtml(e.userEmail)})</td>
+                    <td><span class="status-badge ${e.aiStatus}">${AI_STATUS_LABEL[e.aiStatus] || e.aiStatus}</span></td>
+                    <td>${e.preferredMovingDate || '-'}</td>
+                    <td>${formatDate(e.createdDate)}</td>
+                    <td class="actions">
+                        <button class="btn-detail" onclick="toggleEstimateDetail(${e.estimateId})">상세</button>
+                    </td>
+                `;
+                tbody.appendChild(row);
+
+                if (cfg.state.expandedId === e.estimateId) {
+                    const detail = cfg.state.detailCache[e.estimateId];
+                    const detailRow = document.createElement('tr');
+                    detailRow.className = 'detail-row';
+                    detailRow.innerHTML = `<td colspan="${cfg.colspan}">${renderEstimateDetailContent(detail)}</td>`;
+                    tbody.appendChild(detailRow);
+                }
+            });
+        }
+
+        function renderEstimateDetailContent(detail) {
+            if (!detail) return '불러오는 중...';
+            if (detail.error) return `<span style="color:#dc2626;">${escapeHtml(detail.error)}</span>`;
+
+            const formatLocation = (loc) => loc ? `${escapeHtml(loc.address)} ${escapeHtml(loc.detailAddress || '')}` : '-';
+            const itemsHtml = (detail.items || []).length
+                ? detail.items.map(item => `${item.category} / ${item.itemType} × ${item.quantity}`).join(', ')
+                : '-';
+            const imagesHtml = (detail.images || []).length
+                ? detail.images.map(img => `<a href="${img.imageUrl}" target="_blank" style="color:#2f6feb;">이미지 ${img.imageId}</a>`).join(', ')
+                : '-';
+
+            return `
+                <div>출발지: ${formatLocation(detail.startLocation)}</div>
+                <div>도착지: ${formatLocation(detail.endLocation)}</div>
+                <div>견적 항목: ${itemsHtml}</div>
+                <div>이미지: ${imagesHtml}</div>
+            `;
+        }
+
+        async function toggleEstimateDetail(id) {
+            const cfg = VIEWS.estimates;
+            if (cfg.state.expandedId === id) {
+                cfg.state.expandedId = null;
+                renderTable('estimates', cfg.state.lastList);
+                return;
+            }
+
+            cfg.state.expandedId = id;
+            renderTable('estimates', cfg.state.lastList);
+
+            if (!cfg.state.detailCache[id]) {
+                const { ok, body } = await apiFetch(`/api/v1/admin/estimates/${id}`);
+                cfg.state.detailCache[id] = ok ? body.data : { error: `조회 실패: ${body?.message || ''}` };
+                if (cfg.state.expandedId === id) {
+                    renderTable('estimates', cfg.state.lastList);
+                }
+            }
         }
 
         function toggleDetail(viewKey, id) {

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -579,6 +579,7 @@
                             <div>사업자등록증: ${p.businessRegistrationImageUrl
                                 ? `<a href="${p.businessRegistrationImageUrl}" target="_blank" style="color:#2f6feb;">${p.businessRegistrationImageUrl}</a>`
                                 : '-'}</div>
+                            ${p.approvalStatus === 'REJECTED' ? `<div>반려 사유: ${escapeHtml(p.rejectionReason || '-')}</div>` : ''}
                             <div>유저 ID: ${p.userId}</div>
                         </td>
                     `;
@@ -633,11 +634,20 @@
         }
 
         async function decide(id, approvalStatus) {
-            const label = approvalStatus === 'APPROVED' ? '승인' : '거부';
-            if (!confirm(`이 신청을 ${label}하시겠습니까?`)) return;
+            const requestBody = { approvalStatus };
+
+            if (approvalStatus === 'REJECTED') {
+                const rejectionReason = prompt('반려 사유를 입력하세요.');
+                if (rejectionReason === null) return;
+                if (!rejectionReason.trim()) { alert('반려 사유를 입력해야 합니다.'); return; }
+                requestBody.rejectionReason = rejectionReason.trim();
+            } else if (!confirm('이 신청을 승인하시겠습니까?')) {
+                return;
+            }
+
             const { ok, status, body } = await apiFetch(`/api/v1/admin/partner-applications/${id}`, {
                 method: 'PATCH',
-                body: JSON.stringify({ approvalStatus })
+                body: JSON.stringify(requestBody)
             });
             if (status === 403) { document.getElementById('forbiddenBanner').classList.remove('hidden'); return; }
             if (!ok) { alert(`처리 실패: ${body?.message || status}`); return; }


### PR DESCRIPTION
## 🚀 개요

  - 어드민 페이지를 신규 구현합니다. 파트너 신청/파트너/유저/견적서를 조회·관리할 수 있습니다.   

## ✨ 작업  내용
  - **어드민 페이지 (정적 리소스, `/admin/index.html`)**
      - 소셜 로그인 3종으로 로그인하고, JWT의 role이 ROLE_ADMIN이 아니면 대시보드 진입 자체를 차단 
      - 좌측 사이드바 메뉴: 파트너 신청 관리 / 파트너 관리 / 유저 관리 / 견적서 관리
      - 각 목록에 상태·역할 필터, 키워드 검색(디바운스), 페이지네이션, 로딩 스피너 적용
  - **파트너 신청 관리**
      - 승인/거부 처리, 거부 시 반려 사유 필수 입력 및 상세보기에 노출
  - **파트너 관리**
      - 승인된 파트너 목록 조회, 파트너 권한 해제
  - **유저 관리**
      - 유저 목록 조회(role 필터/키워드 검색), 조회 전용 (비활성화 등 상태 변경 액션은 미포함)
  - **견적서 관리**
      - AI 처리 상태별 목록 조회, 상세보기(위치/이미지/견적 항목), 조회 전용
  - **프론트(모바일/웹) 지원용 API**
      - `GET /api/v1/users/role` — 로그인한 유저 본인의 role 조회 API 추가 

## 🔧 앞으로의 과제

  - 유저 비활성화, 견적서 재시도/강제 실패 처리 등 관리 액션 추가
  - 관리 메뉴 전반에 걸친 요약 통계 홈 대시보드
  - dev/운영 DB의 `users.role` enum에 `PARTNER` 값이 누락되어 있을 가능성 있음 — 배포 전 스키마 확인 필요