### PR TITLE
✨ feat: 파트너 크레딧 충전 TossPayments 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,14 @@ AWS_SECRET_KEY=
 AWS_REGION=
 AWS_S3_BUCKET=
 
+# [파트너 크레딧 - TossPayments]
+TOSS_CLIENT_KEY=
+TOSS_SECRET_KEY=
+TOSS_BASE_URL=https://api.tosspayments.com
+TOSS_SUCCESS_URL=https://isajjim.kro.kr/partner/credits/charge/success
+TOSS_FAIL_URL=https://isajjim.kro.kr/partner/credits/charge/fail
+TOSS_KRW_PER_CREDIT=1
+
 # [소셜 로그인]
 KAKAO_CLIENT_ID=
 KAKAO_CLIENT_SECRET=

--- a/src/main/java/kr/co/isajjim/domains/credit/application/mapper/CreditMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/mapper/CreditMapper.java
@@ -1,5 +1,8 @@
 package kr.co.isajjim.domains.credit.application.mapper;
 
+import kr.co.isajjim.domains.credit.application.response.AdminCreditBalanceOverviewResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditRefundResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditTransactionResponse;
 import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
 import kr.co.isajjim.domains.credit.application.response.CreditChargeConfirmResponse;
 import kr.co.isajjim.domains.credit.application.response.CreditChargeReadyResponse;
@@ -45,6 +48,41 @@ public class CreditMapper {
                 .referenceType(transaction.getReferenceType())
                 .referenceId(transaction.getReferenceId())
                 .createdDate(transaction.getCreatedDate())
+                .build();
+    }
+
+    public static AdminCreditBalanceOverviewResponse toBalanceOverviewResponse(Long userId, String companyName, String representativeName, Long balance) {
+        return AdminCreditBalanceOverviewResponse.builder()
+                .userId(userId)
+                .companyName(companyName)
+                .representativeName(representativeName)
+                .balance(balance)
+                .build();
+    }
+
+    // 관리자 화면에서는 업체명 대신 유저 정보(이름/이메일)로 거래 주체를 식별한다.
+    public static AdminCreditTransactionResponse toAdminTransactionResponse(CreditTransaction transaction) {
+        return AdminCreditTransactionResponse.builder()
+                .transactionId(transaction.getId())
+                .userId(transaction.getUser().getId())
+                .userName(transaction.getUser().getName())
+                .userEmail(transaction.getUser().getEmail())
+                .type(transaction.getType())
+                .creditAmount(transaction.getCreditAmount())
+                .balanceAfter(transaction.getBalanceAfter())
+                .referenceType(transaction.getReferenceType())
+                .referenceId(transaction.getReferenceId())
+                .createdDate(transaction.getCreatedDate())
+                .build();
+    }
+
+    public static AdminCreditRefundResponse toAdminRefundResponse(CreditChargeOrder order, Long balance) {
+        return AdminCreditRefundResponse.builder()
+                .chargeOrderId(order.getId())
+                .userId(order.getUser().getId())
+                .refundedCredit(order.getCreditAmount())
+                .balance(balance)
+                .canceledAt(order.getRefundedAt())
                 .build();
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/application/mapper/CreditMapper.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/mapper/CreditMapper.java
@@ -1,0 +1,50 @@
+package kr.co.isajjim.domains.credit.application.mapper;
+
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeConfirmResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeReadyResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditChargeOrder;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditTransaction;
+
+public class CreditMapper {
+
+    public static CreditChargeReadyResponse toChargeReadyResponse(CreditChargeOrder order, String clientKey, String successUrl, String failUrl) {
+        return CreditChargeReadyResponse.builder()
+                .orderId(order.getOrderId())
+                .orderName(order.getOrderName())
+                .amount(order.getAmount())
+                .creditAmount(order.getCreditAmount())
+                .clientKey(clientKey)
+                .successUrl(successUrl)
+                .failUrl(failUrl)
+                .build();
+    }
+
+    public static CreditChargeConfirmResponse toChargeConfirmResponse(CreditChargeOrder order, Long balance) {
+        return CreditChargeConfirmResponse.builder()
+                .orderId(order.getOrderId())
+                .chargedCredit(order.getCreditAmount())
+                .balance(balance)
+                .approvedAt(order.getApprovedAt())
+                .build();
+    }
+
+    public static CreditBalanceResponse toBalanceResponse(Long balance) {
+        return CreditBalanceResponse.builder()
+                .balance(balance)
+                .build();
+    }
+
+    public static CreditTransactionResponse fromCreditTransaction(CreditTransaction transaction) {
+        return CreditTransactionResponse.builder()
+                .transactionId(transaction.getId())
+                .type(transaction.getType())
+                .creditAmount(transaction.getCreditAmount())
+                .balanceAfter(transaction.getBalanceAfter())
+                .referenceType(transaction.getReferenceType())
+                .referenceId(transaction.getReferenceId())
+                .createdDate(transaction.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/request/AdminCreditRefundRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/request/AdminCreditRefundRequest.java
@@ -1,0 +1,11 @@
+package kr.co.isajjim.domains.credit.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminCreditRefundRequest(
+        @Schema(description = "환불(결제취소) 사유", example = "고객 요청에 의한 충전 취소")
+        @NotBlank
+        String reason
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/request/CreditChargeConfirmRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/request/CreditChargeConfirmRequest.java
@@ -1,0 +1,22 @@
+package kr.co.isajjim.domains.credit.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreditChargeConfirmRequest(
+        @Schema(description = "Toss 결제 키", example = "5EnNZRJGvaBX7zk2yd8ydw2G")
+        @NotBlank
+        String paymentKey,
+
+        @Schema(description = "충전 주문 ID (ready 응답에서 발급받은 값)", example = "credit_a1b2c3d4")
+        @NotBlank
+        String orderId,
+
+        @Schema(description = "결제 금액 (원, ready 요청 시 금액과 일치해야 함)", example = "50000")
+        @NotNull
+        @Positive
+        Long amount
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/request/CreditChargeReadyRequest.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/request/CreditChargeReadyRequest.java
@@ -1,0 +1,13 @@
+package kr.co.isajjim.domains.credit.application.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreditChargeReadyRequest(
+        @Schema(description = "충전 요청 금액 (원)", example = "50000")
+        @NotNull
+        @Positive
+        Long amount
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditBalanceOverviewResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditBalanceOverviewResponse.java
@@ -1,0 +1,20 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AdminCreditBalanceOverviewResponse(
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "업체명", example = "이삿찜 이사")
+        String companyName,
+
+        @Schema(description = "대표자명", example = "홍길동")
+        String representativeName,
+
+        @Schema(description = "현재 크레딧 잔액", example = "50000")
+        Long balance
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditRefundResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditRefundResponse.java
@@ -1,0 +1,25 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record AdminCreditRefundResponse(
+        @Schema(description = "크레딧 충전 주문 ID", example = "1")
+        Long chargeOrderId,
+
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "환불 처리된 크레딧 수량", example = "50000")
+        Long refundedCredit,
+
+        @Schema(description = "환불 후 잔액", example = "0")
+        Long balance,
+
+        @Schema(description = "Toss 결제취소 처리 일시")
+        LocalDateTime canceledAt
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditTransactionResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/AdminCreditTransactionResponse.java
@@ -1,0 +1,41 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.credit.domain.constant.CreditTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record AdminCreditTransactionResponse(
+        @Schema(description = "거래 ID", example = "1")
+        Long transactionId,
+
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "유저 이름", example = "홍길동")
+        String userName,
+
+        @Schema(description = "유저 이메일", example = "partner@example.com")
+        String userEmail,
+
+        @Schema(description = "거래 유형", example = "CHARGE")
+        CreditTransactionType type,
+
+        @Schema(description = "거래 크레딧 수량 (항상 양수)", example = "50000")
+        Long creditAmount,
+
+        @Schema(description = "거래 처리 직후 잔액", example = "50000")
+        Long balanceAfter,
+
+        @Schema(description = "거래 출처 태그", example = "TOSS_CHARGE")
+        String referenceType,
+
+        @Schema(description = "거래 출처 참조 ID (CHARGE인 경우 크레딧 충전 주문 ID)", example = "1")
+        Long referenceId,
+
+        @Schema(description = "거래 일시")
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditBalanceResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditBalanceResponse.java
@@ -1,0 +1,11 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CreditBalanceResponse(
+        @Schema(description = "현재 크레딧 잔액", example = "50000")
+        Long balance
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditChargeConfirmResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditChargeConfirmResponse.java
@@ -1,0 +1,22 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CreditChargeConfirmResponse(
+        @Schema(description = "충전 주문 ID", example = "credit_a1b2c3d4")
+        String orderId,
+
+        @Schema(description = "이번 충전으로 지급된 크레딧 수량", example = "50000")
+        Long chargedCredit,
+
+        @Schema(description = "충전 후 잔액", example = "50000")
+        Long balance,
+
+        @Schema(description = "Toss 결제 승인 일시")
+        LocalDateTime approvedAt
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditChargeReadyResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditChargeReadyResponse.java
@@ -1,0 +1,29 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CreditChargeReadyResponse(
+        @Schema(description = "충전 주문 ID", example = "credit_a1b2c3d4")
+        String orderId,
+
+        @Schema(description = "주문명 (Toss 결제창에 표시)", example = "크레딧 충전 50,000원")
+        String orderName,
+
+        @Schema(description = "충전 요청 금액 (원)", example = "50000")
+        Long amount,
+
+        @Schema(description = "지급될 크레딧 수량", example = "50000")
+        Long creditAmount,
+
+        @Schema(description = "Toss 결제위젯 클라이언트 키")
+        String clientKey,
+
+        @Schema(description = "결제 성공 시 리다이렉트할 URL")
+        String successUrl,
+
+        @Schema(description = "결제 실패 시 리다이렉트할 URL")
+        String failUrl
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditTransactionResponse.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/response/CreditTransactionResponse.java
@@ -1,0 +1,32 @@
+package kr.co.isajjim.domains.credit.application.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.isajjim.domains.credit.domain.constant.CreditTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CreditTransactionResponse(
+        @Schema(description = "거래 ID", example = "1")
+        Long transactionId,
+
+        @Schema(description = "거래 유형", example = "CHARGE")
+        CreditTransactionType type,
+
+        @Schema(description = "거래 크레딧 수량 (항상 양수)", example = "50000")
+        Long creditAmount,
+
+        @Schema(description = "거래 처리 직후 잔액", example = "50000")
+        Long balanceAfter,
+
+        @Schema(description = "거래 출처 태그", example = "TOSS_CHARGE")
+        String referenceType,
+
+        @Schema(description = "거래 출처 참조 ID", example = "1")
+        Long referenceId,
+
+        @Schema(description = "거래 일시")
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/usecase/AdminCreditUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/usecase/AdminCreditUseCase.java
@@ -1,14 +1,30 @@
 package kr.co.isajjim.domains.credit.application.usecase;
 
 import kr.co.isajjim.domains.credit.application.mapper.CreditMapper;
+import kr.co.isajjim.domains.credit.application.request.AdminCreditRefundRequest;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditBalanceOverviewResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditRefundResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditTransactionResponse;
 import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
 import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.domain.service.CreditChargeOrderService;
 import kr.co.isajjim.domains.credit.domain.service.CreditLedgerService;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditChargeOrder;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditTransaction;
+import kr.co.isajjim.domains.user.domain.constant.ApprovalStatus;
+import kr.co.isajjim.domains.user.domain.service.PartnerProfileService;
 import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.infra.toss.domain.service.TossPaymentClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -16,6 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminCreditUseCase {
 
     private final CreditLedgerService creditLedgerService;
+    private final CreditChargeOrderService creditChargeOrderService;
+    private final TossPaymentClient tossPaymentClient;
+    private final PartnerProfileService partnerProfileService;
 
     public CreditBalanceResponse getBalance(Long userId) {
         return CreditMapper.toBalanceResponse(creditLedgerService.getBalance(userId));
@@ -24,5 +43,47 @@ public class AdminCreditUseCase {
     public Page<CreditTransactionResponse> getHistory(Long userId, Pageable pageable) {
         return creditLedgerService.getHistory(userId, pageable)
                 .map(CreditMapper::fromCreditTransaction);
+    }
+
+    // 어드민 - 승인된 파트너 전체의 크레딧 잔액 현황 (업체명/대표자명 검색 지원)
+    public Page<AdminCreditBalanceOverviewResponse> getBalanceOverview(String keyword, Pageable pageable) {
+        return partnerProfileService.getList(ApprovalStatus.APPROVED, keyword, pageable)
+                .map(profile -> CreditMapper.toBalanceOverviewResponse(
+                        profile.getUser().getId(),
+                        profile.getCompanyName(),
+                        profile.getRepresentativeName(),
+                        creditLedgerService.getBalance(profile.getUser().getId())
+                ));
+    }
+
+    // 어드민 - 전체 파트너의 충전/소모/환불 거래내역 (업체명/대표자명 검색 지원)
+    public Page<AdminCreditTransactionResponse> getAllTransactions(String keyword, Pageable pageable) {
+        Page<CreditTransaction> page;
+        if (keyword == null || keyword.isBlank()) {
+            page = creditLedgerService.getAllHistory(pageable);
+        } else {
+            List<Long> userIds = partnerProfileService.findApprovedUserIdsByKeyword(keyword.trim());
+            page = userIds.isEmpty() ? Page.empty(pageable) : creditLedgerService.getHistoryByUserIds(userIds, pageable);
+        }
+        return page.map(CreditMapper::toAdminTransactionResponse);
+    }
+
+    // Toss 결제취소 API 호출(외부 HTTP) 동안 잔액/주문 행 락을 들고 있지 않도록,
+    // confirmCharge와 동일하게 이 메서드만 트랜잭션 밖에서 실행한다.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public AdminCreditRefundResponse refundCharge(Long chargeOrderId, AdminCreditRefundRequest request) {
+        CreditChargeOrder order = creditChargeOrderService.getDoneOrThrow(chargeOrderId);
+
+        try {
+            tossPaymentClient.cancel(order.getPaymentKey(), request.reason());
+        } catch (RuntimeException e) {
+            throw (e instanceof BaseException) ? e : new BaseException(ResponseCode.TOSS_PAYMENT_CANCEL_FAILED);
+        }
+
+        LocalDateTime canceledAt = LocalDateTime.now();
+        CreditChargeOrder refundedOrder = creditChargeOrderService.refundAndDeduct(chargeOrderId, request.reason(), canceledAt);
+        Long balance = creditLedgerService.getBalance(refundedOrder.getUser().getId());
+
+        return CreditMapper.toAdminRefundResponse(refundedOrder, balance);
     }
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/application/usecase/AdminCreditUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/usecase/AdminCreditUseCase.java
@@ -1,0 +1,28 @@
+package kr.co.isajjim.domains.credit.application.usecase;
+
+import kr.co.isajjim.domains.credit.application.mapper.CreditMapper;
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.domain.service.CreditLedgerService;
+import kr.co.isajjim.global.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCreditUseCase {
+
+    private final CreditLedgerService creditLedgerService;
+
+    public CreditBalanceResponse getBalance(Long userId) {
+        return CreditMapper.toBalanceResponse(creditLedgerService.getBalance(userId));
+    }
+
+    public Page<CreditTransactionResponse> getHistory(Long userId, Pageable pageable) {
+        return creditLedgerService.getHistory(userId, pageable)
+                .map(CreditMapper::fromCreditTransaction);
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/application/usecase/CreditUseCase.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/application/usecase/CreditUseCase.java
@@ -1,0 +1,118 @@
+package kr.co.isajjim.domains.credit.application.usecase;
+
+import kr.co.isajjim.domains.credit.application.mapper.CreditMapper;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeConfirmRequest;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeReadyRequest;
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeConfirmResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeReadyResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.domain.service.CreditChargeOrderService;
+import kr.co.isajjim.domains.credit.domain.service.CreditLedgerService;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditChargeOrder;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.annotation.UseCase;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.infra.toss.application.dto.TossConfirmResponse;
+import kr.co.isajjim.infra.toss.domain.service.TossPaymentClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CreditUseCase {
+
+    @Value("${infra.toss.client-key}")
+    private String clientKey;
+
+    @Value("${infra.toss.success-url}")
+    private String successUrl;
+
+    @Value("${infra.toss.fail-url}")
+    private String failUrl;
+
+    @Value("${infra.toss.krw-per-credit}")
+    private Long krwPerCredit;
+
+    private final CreditChargeOrderService creditChargeOrderService;
+    private final CreditLedgerService creditLedgerService;
+    private final TossPaymentClient tossPaymentClient;
+    private final UserService userService;
+
+    @Transactional
+    public CreditChargeReadyResponse readyCharge(Long userId, CreditChargeReadyRequest request) {
+        validateAmount(request.amount());
+
+        UserEntity user = userService.getUserById(userId);
+        String orderId = generateOrderId();
+        Long creditAmount = request.amount() / krwPerCredit;
+        String orderName = String.format("크레딧 충전 %,d원", request.amount());
+
+        CreditChargeOrder order = creditChargeOrderService.createReady(user, orderId, orderName, request.amount(), creditAmount);
+        return CreditMapper.toChargeReadyResponse(order, clientKey, successUrl, failUrl);
+    }
+
+    // Toss 결제 승인 API 호출(최대 rest-client.read-timeout 소요)을 트랜잭션 밖에서 수행하기 위해
+    // 클래스 레벨의 readOnly 트랜잭션을 이 메서드에서만 명시적으로 걷어낸다.
+    // 실제 DB 변경(주문 완료 처리, 잔액 반영)은 각각 별도의 짧은 트랜잭션을 가진 서비스 메서드에서 이뤄진다.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public CreditChargeConfirmResponse confirmCharge(Long userId, CreditChargeConfirmRequest request) {
+        CreditChargeOrder readyOrder = creditChargeOrderService.getReadyOrThrow(request.orderId(), userId);
+        if (!readyOrder.getAmount().equals(request.amount())) {
+            throw new BaseException(ResponseCode.CREDIT_CHARGE_AMOUNT_MISMATCH);
+        }
+
+        TossConfirmResponse tossResponse;
+        try {
+            tossResponse = tossPaymentClient.confirm(request.paymentKey(), request.orderId(), request.amount());
+        } catch (RuntimeException e) {
+            creditChargeOrderService.fail(request.orderId(), userId, e.getMessage());
+            throw (e instanceof BaseException) ? e : new BaseException(ResponseCode.TOSS_PAYMENT_CONFIRM_FAILED);
+        }
+
+        LocalDateTime approvedAt = parseApprovedAt(tossResponse.approvedAt());
+        CreditChargeOrder completedOrder = creditChargeOrderService.completeAndCredit(
+                request.orderId(), userId, tossResponse.paymentKey(), tossResponse.status(), approvedAt
+        );
+        Long balance = creditLedgerService.getBalance(userId);
+
+        return CreditMapper.toChargeConfirmResponse(completedOrder, balance);
+    }
+
+    public CreditBalanceResponse getBalance(Long userId) {
+        return CreditMapper.toBalanceResponse(creditLedgerService.getBalance(userId));
+    }
+
+    public Page<CreditTransactionResponse> getHistory(Long userId, Pageable pageable) {
+        return creditLedgerService.getHistory(userId, pageable)
+                .map(CreditMapper::fromCreditTransaction);
+    }
+
+    private void validateAmount(Long amount) {
+        if (amount == null || amount <= 0 || amount % krwPerCredit != 0) {
+            throw new BaseException(ResponseCode.INVALID_CREDIT_CHARGE_AMOUNT);
+        }
+    }
+
+    private String generateOrderId() {
+        return "credit_" + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private LocalDateTime parseApprovedAt(String approvedAt) {
+        if (approvedAt == null) {
+            return null;
+        }
+        return OffsetDateTime.parse(approvedAt).toLocalDateTime();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditChargeStatus.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditChargeStatus.java
@@ -1,0 +1,7 @@
+package kr.co.isajjim.domains.credit.domain.constant;
+
+public enum CreditChargeStatus {
+    READY,
+    DONE,
+    FAILED
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditChargeStatus.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditChargeStatus.java
@@ -3,5 +3,6 @@ package kr.co.isajjim.domains.credit.domain.constant;
 public enum CreditChargeStatus {
     READY,
     DONE,
-    FAILED
+    FAILED,
+    REFUNDED
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditTransactionType.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditTransactionType.java
@@ -2,5 +2,6 @@ package kr.co.isajjim.domains.credit.domain.constant;
 
 public enum CreditTransactionType {
     CHARGE,
-    CONSUME
+    CONSUME,
+    REFUND
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditTransactionType.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/constant/CreditTransactionType.java
@@ -1,0 +1,6 @@
+package kr.co.isajjim.domains.credit.domain.constant;
+
+public enum CreditTransactionType {
+    CHARGE,
+    CONSUME
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditChargeOrderService.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditChargeOrderService.java
@@ -54,6 +54,30 @@ public class CreditChargeOrderService {
                 .ifPresent(order -> order.fail(failReason));
     }
 
+    // 잠금 없이 조회 + 상태 사전 검증. Toss 결제취소 API를 호출하기 전에 환불 가능 상태인지 걸러낸다.
+    public CreditChargeOrder getDoneOrThrow(Long chargeOrderId) {
+        CreditChargeOrder order = creditChargeOrderRepository.findById(chargeOrderId)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER));
+        if (order.getStatus() != CreditChargeStatus.DONE) {
+            throw new BaseException(ResponseCode.CREDIT_CHARGE_ORDER_NOT_REFUNDABLE);
+        }
+        return order;
+    }
+
+    // Toss 결제취소 성공 이후 행을 다시 잠금 조회해 최종 상태를 재확인한다.
+    // 주문 환불 처리와 잔액 차감을 하나의 트랜잭션으로 묶어 원자적으로 처리한다.
+    @Transactional
+    public CreditChargeOrder refundAndDeduct(Long chargeOrderId, String refundReason, LocalDateTime refundedAt) {
+        CreditChargeOrder order = creditChargeOrderRepository.findByIdForUpdate(chargeOrderId)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER));
+        if (order.getStatus() != CreditChargeStatus.DONE) {
+            throw new BaseException(ResponseCode.CREDIT_CHARGE_ORDER_NOT_REFUNDABLE);
+        }
+        creditLedgerService.refund(order.getUser().getId(), order.getCreditAmount(), "TOSS_REFUND", order.getId());
+        order.refund(refundReason, refundedAt);
+        return order;
+    }
+
     private CreditChargeOrder getOrThrow(String orderId, Long userId) {
         return creditChargeOrderRepository.findByOrderIdAndUser_Id(orderId, userId)
                 .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER));

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditChargeOrderService.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditChargeOrderService.java
@@ -1,0 +1,66 @@
+package kr.co.isajjim.domains.credit.domain.service;
+
+import kr.co.isajjim.domains.credit.domain.constant.CreditChargeStatus;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditChargeOrder;
+import kr.co.isajjim.domains.credit.persistence.repository.CreditChargeOrderRepository;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CreditChargeOrderService {
+
+    private final CreditChargeOrderRepository creditChargeOrderRepository;
+    private final CreditLedgerService creditLedgerService;
+
+    @Transactional
+    public CreditChargeOrder createReady(UserEntity user, String orderId, String orderName, Long amount, Long creditAmount) {
+        CreditChargeOrder order = CreditChargeOrder.create(user, orderId, orderName, amount, creditAmount);
+        return creditChargeOrderRepository.save(order);
+    }
+
+    // 잠금 없이 조회 + 상태 사전 검증. Toss 승인 API를 호출하기 전에 걸러내어 불필요한 외부 호출과 변조된 금액 확인을 막는다.
+    public CreditChargeOrder getReadyOrThrow(String orderId, Long userId) {
+        CreditChargeOrder order = getOrThrow(orderId, userId);
+        if (order.getStatus() != CreditChargeStatus.READY) {
+            throw new BaseException(ResponseCode.ALREADY_PROCESSED_CREDIT_CHARGE_ORDER);
+        }
+        return order;
+    }
+
+    // Toss 승인 성공 이후 행을 다시 잠금 조회해 최종 상태를 재확인한다. 진짜 동시 이중 confirm은 여기서 걸러진다.
+    // 주문 완료 처리와 잔액 반영을 하나의 트랜잭션으로 묶어, 둘 중 하나만 반영되는 상황을 방지한다.
+    @Transactional
+    public CreditChargeOrder completeAndCredit(String orderId, Long userId, String paymentKey, String tossStatus, LocalDateTime approvedAt) {
+        CreditChargeOrder order = getOrThrowForUpdate(orderId, userId);
+        if (order.getStatus() != CreditChargeStatus.READY) {
+            throw new BaseException(ResponseCode.ALREADY_PROCESSED_CREDIT_CHARGE_ORDER);
+        }
+        order.complete(paymentKey, tossStatus, approvedAt);
+        creditLedgerService.chargeBalance(userId, order.getCreditAmount(), "TOSS_CHARGE", order.getId());
+        return order;
+    }
+
+    @Transactional
+    public void fail(String orderId, Long userId, String failReason) {
+        creditChargeOrderRepository.findByOrderIdAndUser_IdForUpdate(orderId, userId)
+                .filter(order -> order.getStatus() == CreditChargeStatus.READY)
+                .ifPresent(order -> order.fail(failReason));
+    }
+
+    private CreditChargeOrder getOrThrow(String orderId, Long userId) {
+        return creditChargeOrderRepository.findByOrderIdAndUser_Id(orderId, userId)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER));
+    }
+
+    private CreditChargeOrder getOrThrowForUpdate(String orderId, Long userId) {
+        return creditChargeOrderRepository.findByOrderIdAndUser_IdForUpdate(orderId, userId)
+                .orElseThrow(() -> new BaseException(ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditLedgerService.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditLedgerService.java
@@ -1,5 +1,6 @@
 package kr.co.isajjim.domains.credit.domain.service;
 
+import kr.co.isajjim.domains.credit.domain.constant.CreditTransactionType;
 import kr.co.isajjim.domains.credit.persistence.entity.CreditBalance;
 import kr.co.isajjim.domains.credit.persistence.entity.CreditTransaction;
 import kr.co.isajjim.domains.credit.persistence.repository.CreditBalanceRepository;
@@ -15,6 +16,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,16 @@ public class CreditLedgerService {
         return creditTransactionRepository.findByUser_Id(userId, pageable);
     }
 
+    // 어드민 - 전체 파트너 거래내역 (검색어 없음)
+    public Page<CreditTransaction> getAllHistory(Pageable pageable) {
+        return creditTransactionRepository.findAll(pageable);
+    }
+
+    // 어드민 - 특정 유저 ID 목록(업체명 검색 결과)으로 좁힌 거래내역
+    public Page<CreditTransaction> getHistoryByUserIds(List<Long> userIds, Pageable pageable) {
+        return creditTransactionRepository.findByUser_IdIn(userIds, pageable);
+    }
+
     @Transactional
     public Long chargeBalance(Long userId, Long creditAmount, String referenceType, Long referenceId) {
         CreditBalance balance = getOrCreateForUpdate(userId);
@@ -48,8 +61,18 @@ public class CreditLedgerService {
     // 향후 "견적서 발송" 등에서 이 서비스를 직접 주입받아 호출할 크레딧 소모 메서드.
     @Transactional
     public Long consume(Long userId, Long creditAmount, String referenceType, Long referenceId) {
+        return decrease(userId, creditAmount, CreditTransactionType.CONSUME, referenceType, referenceId);
+    }
+
+    // 어드민의 Toss 결제취소(환불) 승인 이후, 해당 금액만큼 크레딧 잔액을 차감한다.
+    @Transactional
+    public Long refund(Long userId, Long creditAmount, String referenceType, Long referenceId) {
+        return decrease(userId, creditAmount, CreditTransactionType.REFUND, referenceType, referenceId);
+    }
+
+    private Long decrease(Long userId, Long creditAmount, CreditTransactionType type, String referenceType, Long referenceId) {
         if (creditAmount == null || creditAmount <= 0) {
-            throw new IllegalArgumentException("소모할 크레딧 수량은 0보다 커야 합니다.");
+            throw new IllegalArgumentException("차감할 크레딧 수량은 0보다 커야 합니다.");
         }
 
         CreditBalance balance = getOrCreateForUpdate(userId);
@@ -58,9 +81,10 @@ public class CreditLedgerService {
         }
 
         balance.decrease(creditAmount);
-        creditTransactionRepository.save(
-                CreditTransaction.consume(balance.getUser(), creditAmount, balance.getBalance(), referenceType, referenceId)
-        );
+        CreditTransaction transaction = type == CreditTransactionType.REFUND
+                ? CreditTransaction.refund(balance.getUser(), creditAmount, balance.getBalance(), referenceType, referenceId)
+                : CreditTransaction.consume(balance.getUser(), creditAmount, balance.getBalance(), referenceType, referenceId);
+        creditTransactionRepository.save(transaction);
         return balance.getBalance();
     }
 

--- a/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditLedgerService.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/domain/service/CreditLedgerService.java
@@ -1,0 +1,90 @@
+package kr.co.isajjim.domains.credit.domain.service;
+
+import kr.co.isajjim.domains.credit.persistence.entity.CreditBalance;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditTransaction;
+import kr.co.isajjim.domains.credit.persistence.repository.CreditBalanceRepository;
+import kr.co.isajjim.domains.credit.persistence.repository.CreditTransactionRepository;
+import kr.co.isajjim.domains.user.domain.service.UserService;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreditLedgerService {
+
+    private final CreditBalanceRepository creditBalanceRepository;
+    private final CreditTransactionRepository creditTransactionRepository;
+    private final UserService userService;
+
+    // 잔액 조회 전용 (GET 응답). 잔액 행이 아직 없으면 0을 반환하며 행을 생성하지 않는다.
+    public Long getBalance(Long userId) {
+        return creditBalanceRepository.findByUser_Id(userId)
+                .map(CreditBalance::getBalance)
+                .orElse(0L);
+    }
+
+    public Page<CreditTransaction> getHistory(Long userId, Pageable pageable) {
+        return creditTransactionRepository.findByUser_Id(userId, pageable);
+    }
+
+    @Transactional
+    public Long chargeBalance(Long userId, Long creditAmount, String referenceType, Long referenceId) {
+        CreditBalance balance = getOrCreateForUpdate(userId);
+        balance.increase(creditAmount);
+        creditTransactionRepository.save(
+                CreditTransaction.charge(balance.getUser(), creditAmount, balance.getBalance(), referenceType, referenceId)
+        );
+        return balance.getBalance();
+    }
+
+    // 향후 "견적서 발송" 등에서 이 서비스를 직접 주입받아 호출할 크레딧 소모 메서드.
+    @Transactional
+    public Long consume(Long userId, Long creditAmount, String referenceType, Long referenceId) {
+        if (creditAmount == null || creditAmount <= 0) {
+            throw new IllegalArgumentException("소모할 크레딧 수량은 0보다 커야 합니다.");
+        }
+
+        CreditBalance balance = getOrCreateForUpdate(userId);
+        if (balance.getBalance() < creditAmount) {
+            throw new BaseException(ResponseCode.INSUFFICIENT_CREDIT);
+        }
+
+        balance.decrease(creditAmount);
+        creditTransactionRepository.save(
+                CreditTransaction.consume(balance.getUser(), creditAmount, balance.getBalance(), referenceType, referenceId)
+        );
+        return balance.getBalance();
+    }
+
+    private CreditBalance getOrCreateForUpdate(Long userId) {
+        return creditBalanceRepository.findByUser_IdForUpdate(userId)
+                .orElseGet(() -> {
+                    createIfAbsent(userId);
+                    return creditBalanceRepository.findByUser_IdForUpdate(userId)
+                            .orElseThrow(() -> new BaseException(ResponseCode.INTERNAL_SERVER_ERROR));
+                });
+    }
+
+    // 잔액 행을 별도의 새 트랜잭션에서 생성한다. 동시 최초-생성 경합으로 unique(user_id) 제약이 걸려도
+    // 이 트랜잭션만 롤백되고, 호출부의 원래 트랜잭션(잠금 재조회)은 영향받지 않는다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createIfAbsent(Long userId) {
+        if (creditBalanceRepository.findByUser_Id(userId).isPresent()) {
+            return;
+        }
+        UserEntity user = userService.getUserById(userId);
+        try {
+            creditBalanceRepository.saveAndFlush(CreditBalance.createEmpty(user));
+        } catch (DataIntegrityViolationException e) {
+            // 동시에 다른 트랜잭션이 먼저 생성을 완료한 경우. 호출부에서 재조회하므로 무시한다.
+        }
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditBalance.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditBalance.java
@@ -1,0 +1,44 @@
+package kr.co.isajjim.domains.credit.persistence.entity;
+
+import jakarta.persistence.*;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.base.entity.BaseEntity;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "credit_balances")
+@Builder(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditBalance extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "credit_balance_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private UserEntity user;
+
+    private Long balance;
+
+    public static CreditBalance createEmpty(UserEntity user) {
+        return CreditBalance.builder()
+                .user(user)
+                .balance(0L)
+                .build();
+    }
+
+    public void increase(Long amount) {
+        this.balance += amount;
+    }
+
+    public void decrease(Long amount) {
+        if (this.balance < amount) {
+            throw new IllegalStateException("보유 크레딧이 부족합니다.");
+        }
+        this.balance -= amount;
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditChargeOrder.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditChargeOrder.java
@@ -1,0 +1,91 @@
+package kr.co.isajjim.domains.credit.persistence.entity;
+
+import jakarta.persistence.*;
+import kr.co.isajjim.domains.credit.domain.constant.CreditChargeStatus;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.base.entity.BaseEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(
+        name = "credit_charge_orders",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_credit_charge_order_order_id", columnNames = {"order_id"})
+        },
+        indexes = {
+                @Index(name = "idx_credit_charge_order_user", columnList = "user_id")
+        }
+)
+@Builder(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditChargeOrder extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "credit_charge_order_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    // 서버가 생성하는 주문 식별자. 클라이언트가 지정한 값을 신뢰하지 않는다.
+    @Column(name = "order_id", nullable = false, length = 64)
+    private String orderId;
+
+    private String orderName;
+
+    // 원화 충전 요청 금액. 최초 요청 이후 불변 (confirm 시 변조 여부 대조 기준).
+    private Long amount;
+
+    // ready 시점의 환산 비율로 계산해 저장. 이후 비율 설정이 바뀌어도 이미 생성된 주문 가치는 변하지 않는다.
+    private Long creditAmount;
+
+    @Enumerated(EnumType.STRING)
+    private CreditChargeStatus status;
+
+    private String paymentKey;
+
+    // Toss 응답의 status 원문 (감사/디버깅용)
+    private String tossStatus;
+
+    private LocalDateTime approvedAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String failReason;
+
+    public static CreditChargeOrder create(UserEntity user, String orderId, String orderName, Long amount, Long creditAmount) {
+        return CreditChargeOrder.builder()
+                .user(user)
+                .orderId(orderId)
+                .orderName(orderName)
+                .amount(amount)
+                .creditAmount(creditAmount)
+                .status(CreditChargeStatus.READY)
+                .build();
+    }
+
+    public void complete(String paymentKey, String tossStatus, LocalDateTime approvedAt) {
+        assertReady();
+        this.status = CreditChargeStatus.DONE;
+        this.paymentKey = paymentKey;
+        this.tossStatus = tossStatus;
+        this.approvedAt = approvedAt;
+    }
+
+    public void fail(String failReason) {
+        assertReady();
+        this.status = CreditChargeStatus.FAILED;
+        this.failReason = failReason;
+    }
+
+    private void assertReady() {
+        if (this.status != CreditChargeStatus.READY) {
+            throw new IllegalStateException("이미 처리된 크레딧 충전 주문입니다.");
+        }
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditChargeOrder.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditChargeOrder.java
@@ -58,6 +58,11 @@ public class CreditChargeOrder extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String failReason;
 
+    @Column(columnDefinition = "TEXT")
+    private String refundReason;
+
+    private LocalDateTime refundedAt;
+
     public static CreditChargeOrder create(UserEntity user, String orderId, String orderName, Long amount, Long creditAmount) {
         return CreditChargeOrder.builder()
                 .user(user)
@@ -81,6 +86,16 @@ public class CreditChargeOrder extends BaseEntity {
         assertReady();
         this.status = CreditChargeStatus.FAILED;
         this.failReason = failReason;
+    }
+
+    // Toss 결제취소가 성공한 뒤에만 호출된다. DONE 상태(정상 충전 완료)만 환불 대상이다.
+    public void refund(String refundReason, LocalDateTime refundedAt) {
+        if (this.status != CreditChargeStatus.DONE) {
+            throw new IllegalStateException("환불 가능한 상태의 충전 건이 아닙니다.");
+        }
+        this.status = CreditChargeStatus.REFUNDED;
+        this.refundReason = refundReason;
+        this.refundedAt = refundedAt;
     }
 
     private void assertReady() {

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditTransaction.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditTransaction.java
@@ -51,6 +51,10 @@ public class CreditTransaction extends BaseEntity {
         return of(user, CreditTransactionType.CONSUME, creditAmount, balanceAfter, referenceType, referenceId);
     }
 
+    public static CreditTransaction refund(UserEntity user, Long creditAmount, Long balanceAfter, String referenceType, Long referenceId) {
+        return of(user, CreditTransactionType.REFUND, creditAmount, balanceAfter, referenceType, referenceId);
+    }
+
     private static CreditTransaction of(UserEntity user, CreditTransactionType type, Long creditAmount, Long balanceAfter, String referenceType, Long referenceId) {
         return CreditTransaction.builder()
                 .user(user)

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditTransaction.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/entity/CreditTransaction.java
@@ -1,0 +1,64 @@
+package kr.co.isajjim.domains.credit.persistence.entity;
+
+import jakarta.persistence.*;
+import kr.co.isajjim.domains.credit.domain.constant.CreditTransactionType;
+import kr.co.isajjim.domains.user.persistence.entity.UserEntity;
+import kr.co.isajjim.global.base.entity.BaseEntity;
+import lombok.*;
+
+// 충전/소모 내역을 남기는 append-only 원장. 생성 후 필드를 변경하는 메서드는 두지 않는다.
+@Entity
+@Getter
+@Table(
+        name = "credit_transactions",
+        indexes = {
+                @Index(name = "idx_credit_tx_user_created", columnList = "user_id, created_date")
+        }
+)
+@Builder(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditTransaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "credit_transaction_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Enumerated(EnumType.STRING)
+    private CreditTransactionType type;
+
+    // 항상 양수. 부호는 type으로 판단한다.
+    private Long creditAmount;
+
+    // 이 거래 처리 직후의 잔액 스냅샷 (분쟁/정산 대조용)
+    private Long balanceAfter;
+
+    // 이 거래를 발생시킨 출처 태그. 예: "TOSS_CHARGE", 추후 "ESTIMATE_DISPATCH" 등 호출자가 자유롭게 지정.
+    private String referenceType;
+
+    private Long referenceId;
+
+    public static CreditTransaction charge(UserEntity user, Long creditAmount, Long balanceAfter, String referenceType, Long referenceId) {
+        return of(user, CreditTransactionType.CHARGE, creditAmount, balanceAfter, referenceType, referenceId);
+    }
+
+    public static CreditTransaction consume(UserEntity user, Long creditAmount, Long balanceAfter, String referenceType, Long referenceId) {
+        return of(user, CreditTransactionType.CONSUME, creditAmount, balanceAfter, referenceType, referenceId);
+    }
+
+    private static CreditTransaction of(UserEntity user, CreditTransactionType type, Long creditAmount, Long balanceAfter, String referenceType, Long referenceId) {
+        return CreditTransaction.builder()
+                .user(user)
+                .type(type)
+                .creditAmount(creditAmount)
+                .balanceAfter(balanceAfter)
+                .referenceType(referenceType)
+                .referenceId(referenceId)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditBalanceRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditBalanceRepository.java
@@ -1,0 +1,20 @@
+package kr.co.isajjim.domains.credit.persistence.repository;
+
+import jakarta.persistence.LockModeType;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditBalance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CreditBalanceRepository extends JpaRepository<CreditBalance, Long> {
+
+    // 잔액 조회 전용 (GET 응답 등). 락을 걸거나 행을 생성하지 않는다.
+    Optional<CreditBalance> findByUser_Id(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM CreditBalance b WHERE b.user.id = :userId")
+    Optional<CreditBalance> findByUser_IdForUpdate(@Param("userId") Long userId);
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditChargeOrderRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditChargeOrderRepository.java
@@ -16,4 +16,8 @@ public interface CreditChargeOrderRepository extends JpaRepository<CreditChargeO
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT o FROM CreditChargeOrder o WHERE o.orderId = :orderId AND o.user.id = :userId")
     Optional<CreditChargeOrder> findByOrderIdAndUser_IdForUpdate(@Param("orderId") String orderId, @Param("userId") Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM CreditChargeOrder o WHERE o.id = :id")
+    Optional<CreditChargeOrder> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditChargeOrderRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditChargeOrderRepository.java
@@ -1,0 +1,19 @@
+package kr.co.isajjim.domains.credit.persistence.repository;
+
+import jakarta.persistence.LockModeType;
+import kr.co.isajjim.domains.credit.persistence.entity.CreditChargeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CreditChargeOrderRepository extends JpaRepository<CreditChargeOrder, Long> {
+
+    Optional<CreditChargeOrder> findByOrderIdAndUser_Id(String orderId, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM CreditChargeOrder o WHERE o.orderId = :orderId AND o.user.id = :userId")
+    Optional<CreditChargeOrder> findByOrderIdAndUser_IdForUpdate(@Param("orderId") String orderId, @Param("userId") Long userId);
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditTransactionRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditTransactionRepository.java
@@ -1,0 +1,11 @@
+package kr.co.isajjim.domains.credit.persistence.repository;
+
+import kr.co.isajjim.domains.credit.persistence.entity.CreditTransaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreditTransactionRepository extends JpaRepository<CreditTransaction, Long> {
+
+    Page<CreditTransaction> findByUser_Id(Long userId, Pageable pageable);
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditTransactionRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/persistence/repository/CreditTransactionRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CreditTransactionRepository extends JpaRepository<CreditTransaction, Long> {
 
     Page<CreditTransaction> findByUser_Id(Long userId, Pageable pageable);
+
+    Page<CreditTransaction> findByUser_IdIn(List<Long> userIds, Pageable pageable);
 }

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/api/AdminCreditApi.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/api/AdminCreditApi.java
@@ -1,0 +1,57 @@
+package kr.co.isajjim.domains.credit.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Admin Credit", description = "어드민 - 파트너 크레딧 조회 API")
+public interface AdminCreditApi {
+
+    @Operation(
+            summary = "파트너 크레딧 잔액 조회",
+            description = "CS/분쟁 대응을 위해 관리자가 특정 파트너의 크레딧 잔액을 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditBalanceResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    ResponseEntity<ApiResponse<CreditBalanceResponse>> getBalance(
+            @PathVariable Long userId
+    );
+
+    @Operation(
+            summary = "파트너 크레딧 거래 내역 조회",
+            description = "CS/분쟁 대응을 위해 관리자가 특정 파트너의 충전/소모 거래 내역을 최신순으로 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditTransactionResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<CreditTransactionResponse>>> getHistory(
+            @PathVariable Long userId,
+            @Parameter(hidden = true) Pageable pageable
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/api/AdminCreditOverviewApi.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/api/AdminCreditOverviewApi.java
@@ -1,0 +1,89 @@
+package kr.co.isajjim.domains.credit.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.credit.application.request.AdminCreditRefundRequest;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditBalanceOverviewResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditRefundResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditTransactionResponse;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin Credit Overview", description = "어드민 - 전체 파트너 크레딧 현황/환불 API")
+public interface AdminCreditOverviewApi {
+
+    @Operation(
+            summary = "전체 파트너 크레딧 잔액 현황 조회",
+            description = "승인된 파트너 전체의 현재 크레딧 잔액을 업체명/대표자명 키워드로 검색하여 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = AdminCreditBalanceOverviewResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<AdminCreditBalanceOverviewResponse>>> getBalanceOverview(
+            @Parameter(in = ParameterIn.QUERY, description = "업체명/대표자명 검색 키워드", example = "이삿찜")
+            @RequestParam(required = false) String keyword,
+            @Parameter(hidden = true) Pageable pageable
+    );
+
+    @Operation(
+            summary = "전체 파트너 크레딧 거래내역 조회",
+            description = "전체 파트너의 충전/소모/환불 거래내역을 업체명/대표자명 키워드로 검색하여 최신순으로 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = AdminCreditTransactionResponse.class,
+                    description = "조회 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN)
+            }
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<AdminCreditTransactionResponse>>> getAllTransactions(
+            @Parameter(in = ParameterIn.QUERY, description = "업체명/대표자명 검색 키워드", example = "이삿찜")
+            @RequestParam(required = false) String keyword,
+            @Parameter(hidden = true) Pageable pageable
+    );
+
+    @Operation(
+            summary = "크레딧 충전 건 환불",
+            description = "지정한 충전 건(chargeOrderId)에 대해 TossPayments 결제취소 API를 호출하고, 성공 시 해당 크레딧만큼 잔액을 차감합니다. 전액 환불만 지원하며, 이미 환불되었거나 정상 충전 완료(DONE) 상태가 아닌 건은 환불할 수 없습니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = AdminCreditRefundResponse.class,
+                    description = "환불 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.FORBIDDEN),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.CREDIT_CHARGE_ORDER_NOT_REFUNDABLE),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INSUFFICIENT_CREDIT),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.TOSS_PAYMENT_CANCEL_FAILED)
+            }
+    )
+    ResponseEntity<ApiResponse<AdminCreditRefundResponse>> refundCharge(
+            @PathVariable Long chargeOrderId,
+            @RequestBody @Valid AdminCreditRefundRequest request
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/api/PartnerCreditApi.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/api/PartnerCreditApi.java
@@ -1,0 +1,97 @@
+package kr.co.isajjim.domains.credit.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeConfirmRequest;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeReadyRequest;
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeConfirmResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeReadyResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.global.annotation.swagger.ApiErrorResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.ApiResponseExplanations;
+import kr.co.isajjim.global.annotation.swagger.ApiSuccessResponseExplanation;
+import kr.co.isajjim.global.annotation.swagger.PageableAsQueryParam;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Partner Credit", description = "파트너 - 크레딧 충전/조회 API")
+public interface PartnerCreditApi {
+
+    @Operation(
+            summary = "크레딧 충전 주문 생성",
+            description = "TossPayments 결제위젯 호출에 필요한 주문 정보를 생성합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditChargeReadyResponse.class,
+                    description = "주문 생성 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.INVALID_CREDIT_CHARGE_AMOUNT)
+            }
+    )
+    ResponseEntity<ApiResponse<CreditChargeReadyResponse>> readyCharge(
+            @RequestBody @Valid CreditChargeReadyRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "크레딧 충전 승인",
+            description = "TossPayments 결제 승인을 요청하고, 성공 시 크레딧을 충전합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditChargeConfirmResponse.class,
+                    description = "충전 성공"
+            ),
+            errors = {
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.NOT_FOUND_CREDIT_CHARGE_ORDER),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.ALREADY_PROCESSED_CREDIT_CHARGE_ORDER),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.CREDIT_CHARGE_AMOUNT_MISMATCH),
+                    @ApiErrorResponseExplanation(exceptionCode = ResponseCode.TOSS_PAYMENT_CONFIRM_FAILED)
+            }
+    )
+    ResponseEntity<ApiResponse<CreditChargeConfirmResponse>> confirmCharge(
+            @RequestBody @Valid CreditChargeConfirmRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "내 크레딧 잔액 조회",
+            description = "현재 로그인한 파트너의 크레딧 잔액을 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditBalanceResponse.class,
+                    description = "조회 성공"
+            )
+    )
+    ResponseEntity<ApiResponse<CreditBalanceResponse>> getBalance(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "내 크레딧 거래 내역 조회",
+            description = "현재 로그인한 파트너의 충전/소모 거래 내역을 최신순으로 조회합니다."
+    )
+    @ApiResponseExplanations(
+            success = @ApiSuccessResponseExplanation(
+                    responseClass = CreditTransactionResponse.class,
+                    description = "조회 성공"
+            )
+    )
+    @PageableAsQueryParam
+    ResponseEntity<ApiResponse<Page<CreditTransactionResponse>>> getHistory(
+            @Parameter(hidden = true) Pageable pageable,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user
+    );
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/AdminCreditController.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/AdminCreditController.java
@@ -1,0 +1,42 @@
+package kr.co.isajjim.domains.credit.presentation.controller;
+
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.application.usecase.AdminCreditUseCase;
+import kr.co.isajjim.domains.credit.presentation.api.AdminCreditApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/partners/{userId}/credits")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminCreditController implements AdminCreditApi {
+
+    private final AdminCreditUseCase adminCreditUseCase;
+
+    @Override
+    @GetMapping("/balance")
+    public ResponseEntity<ApiResponse<CreditBalanceResponse>> getBalance(
+            @PathVariable Long userId
+    ) {
+        CreditBalanceResponse response = adminCreditUseCase.getBalance(userId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/transactions")
+    public ResponseEntity<ApiResponse<Page<CreditTransactionResponse>>> getHistory(
+            @PathVariable Long userId,
+            Pageable pageable
+    ) {
+        Page<CreditTransactionResponse> response = adminCreditUseCase.getHistory(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/AdminCreditOverviewController.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/AdminCreditOverviewController.java
@@ -1,0 +1,56 @@
+package kr.co.isajjim.domains.credit.presentation.controller;
+
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.credit.application.request.AdminCreditRefundRequest;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditBalanceOverviewResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditRefundResponse;
+import kr.co.isajjim.domains.credit.application.response.AdminCreditTransactionResponse;
+import kr.co.isajjim.domains.credit.application.usecase.AdminCreditUseCase;
+import kr.co.isajjim.domains.credit.presentation.api.AdminCreditOverviewApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/credits")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminCreditOverviewController implements AdminCreditOverviewApi {
+
+    private final AdminCreditUseCase adminCreditUseCase;
+
+    @Override
+    @GetMapping("/balances")
+    public ResponseEntity<ApiResponse<Page<AdminCreditBalanceOverviewResponse>>> getBalanceOverview(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+    ) {
+        Page<AdminCreditBalanceOverviewResponse> response = adminCreditUseCase.getBalanceOverview(keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/transactions")
+    public ResponseEntity<ApiResponse<Page<AdminCreditTransactionResponse>>> getAllTransactions(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+    ) {
+        Page<AdminCreditTransactionResponse> response = adminCreditUseCase.getAllTransactions(keyword, pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @PostMapping("/charges/{chargeOrderId}/refund")
+    public ResponseEntity<ApiResponse<AdminCreditRefundResponse>> refundCharge(
+            @PathVariable Long chargeOrderId,
+            @RequestBody @Valid AdminCreditRefundRequest request
+    ) {
+        AdminCreditRefundResponse response = adminCreditUseCase.refundCharge(chargeOrderId, request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/PartnerCreditController.java
+++ b/src/main/java/kr/co/isajjim/domains/credit/presentation/controller/PartnerCreditController.java
@@ -1,0 +1,69 @@
+package kr.co.isajjim.domains.credit.presentation.controller;
+
+import jakarta.validation.Valid;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeConfirmRequest;
+import kr.co.isajjim.domains.credit.application.request.CreditChargeReadyRequest;
+import kr.co.isajjim.domains.credit.application.response.CreditBalanceResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeConfirmResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditChargeReadyResponse;
+import kr.co.isajjim.domains.credit.application.response.CreditTransactionResponse;
+import kr.co.isajjim.domains.credit.application.usecase.CreditUseCase;
+import kr.co.isajjim.domains.credit.presentation.api.PartnerCreditApi;
+import kr.co.isajjim.global.common.ApiResponse;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/partner-credits")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('PARTNER')")
+public class PartnerCreditController implements PartnerCreditApi {
+
+    private final CreditUseCase creditUseCase;
+
+    @Override
+    @PostMapping("/charges/ready")
+    public ResponseEntity<ApiResponse<CreditChargeReadyResponse>> readyCharge(
+            @RequestBody @Valid CreditChargeReadyRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CreditChargeReadyResponse response = creditUseCase.readyCharge(user.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @PostMapping("/charges/confirm")
+    public ResponseEntity<ApiResponse<CreditChargeConfirmResponse>> confirmCharge(
+            @RequestBody @Valid CreditChargeConfirmRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CreditChargeConfirmResponse response = creditUseCase.confirmCharge(user.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/balance")
+    public ResponseEntity<ApiResponse<CreditBalanceResponse>> getBalance(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CreditBalanceResponse response = creditUseCase.getBalance(user.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    @Override
+    @GetMapping("/transactions")
+    public ResponseEntity<ApiResponse<Page<CreditTransactionResponse>>> getHistory(
+            Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Page<CreditTransactionResponse> response = creditUseCase.getHistory(user.getUserId(), pageable);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
+++ b/src/main/java/kr/co/isajjim/domains/user/domain/service/PartnerProfileService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PartnerProfileService {
@@ -34,6 +36,11 @@ public class PartnerProfileService {
 
     public Page<PartnerProfile> getList(ApprovalStatus approvalStatus, String keyword, Pageable pageable) {
         return partnerProfileRepository.search(approvalStatus, normalizeKeyword(keyword), pageable);
+    }
+
+    // 승인된 파트너 중 업체명/대표자명이 keyword와 일치하는 유저 ID 목록. 크레딧 거래내역을 업체명으로 검색할 때 사용.
+    public List<Long> findApprovedUserIdsByKeyword(String keyword) {
+        return partnerProfileRepository.findUserIdsByApprovalStatusAndKeyword(ApprovalStatus.APPROVED, keyword);
     }
 
     private String normalizeKeyword(String keyword) {

--- a/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
+++ b/src/main/java/kr/co/isajjim/domains/user/persistence/repository/PartnerProfileRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PartnerProfileRepository extends JpaRepository<PartnerProfile, Long> {
@@ -27,5 +28,16 @@ public interface PartnerProfileRepository extends JpaRepository<PartnerProfile, 
             @Param("approvalStatus") ApprovalStatus approvalStatus,
             @Param("keyword") String keyword,
             Pageable pageable
+    );
+
+    @Query("""
+            SELECT p.user.id FROM PartnerProfile p
+            WHERE p.approvalStatus = :approvalStatus
+            AND (p.companyName LIKE CONCAT('%', :keyword, '%')
+                OR p.representativeName LIKE CONCAT('%', :keyword, '%'))
+            """)
+    List<Long> findUserIdsByApprovalStatusAndKeyword(
+            @Param("approvalStatus") ApprovalStatus approvalStatus,
+            @Param("keyword") String keyword
     );
 }

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -65,6 +65,15 @@ public enum ResponseCode {
     DUPLICATE_PARTNER_APPLICATION(HttpStatus.BAD_REQUEST, "PARTNER-002", "이미 파트너 신청 내역이 존재합니다."),
     INVALID_APPROVAL_STATUS(HttpStatus.BAD_REQUEST, "PARTNER-003", "승인 처리 값은 APPROVED 또는 REJECTED만 가능합니다."),
     REQUIRED_REJECTION_REASON(HttpStatus.BAD_REQUEST, "PARTNER-004", "거부 처리 시 반려 사유는 필수입니다."),
+
+
+    /*    Credit    */
+    NOT_FOUND_CREDIT_CHARGE_ORDER(HttpStatus.NOT_FOUND, "CREDIT-001", "요청 크레딧 충전 주문을 찾을 수 없습니다."),
+    ALREADY_PROCESSED_CREDIT_CHARGE_ORDER(HttpStatus.CONFLICT, "CREDIT-002", "이미 처리된 크레딧 충전 주문입니다."),
+    CREDIT_CHARGE_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "CREDIT-003", "충전 요청 금액이 최초 요청 금액과 일치하지 않습니다."),
+    INVALID_CREDIT_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "CREDIT-004", "충전 금액은 지정된 단위의 배수여야 합니다."),
+    TOSS_PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "CREDIT-005", "결제 승인에 실패했습니다."),
+    INSUFFICIENT_CREDIT(HttpStatus.CONFLICT, "CREDIT-006", "보유 크레딧이 부족합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
+++ b/src/main/java/kr/co/isajjim/global/common/ResponseCode.java
@@ -74,6 +74,8 @@ public enum ResponseCode {
     INVALID_CREDIT_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, "CREDIT-004", "충전 금액은 지정된 단위의 배수여야 합니다."),
     TOSS_PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "CREDIT-005", "결제 승인에 실패했습니다."),
     INSUFFICIENT_CREDIT(HttpStatus.CONFLICT, "CREDIT-006", "보유 크레딧이 부족합니다."),
+    TOSS_PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "CREDIT-007", "결제 취소(환불)에 실패했습니다."),
+    CREDIT_CHARGE_ORDER_NOT_REFUNDABLE(HttpStatus.CONFLICT, "CREDIT-008", "환불 가능한 상태의 충전 건이 아닙니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossCancelRequest.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossCancelRequest.java
@@ -1,0 +1,6 @@
+package kr.co.isajjim.infra.toss.application.dto;
+
+public record TossCancelRequest(
+        String cancelReason
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossConfirmRequest.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossConfirmRequest.java
@@ -1,0 +1,8 @@
+package kr.co.isajjim.infra.toss.application.dto;
+
+public record TossConfirmRequest(
+        String paymentKey,
+        String orderId,
+        Long amount
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossConfirmResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossConfirmResponse.java
@@ -1,0 +1,15 @@
+package kr.co.isajjim.infra.toss.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+// Toss 결제 승인 응답은 이 외에도 훨씬 많은 필드를 담고 있으나, 이 도메인에서 실제로 사용하는 값만 매핑한다.
+// approvedAt은 오프셋 포함 ISO-8601 문자열(예: "2024-01-01T00:00:00+09:00")로 내려오므로 그대로 문자열로 받아 서비스 계층에서 파싱한다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossConfirmResponse(
+        String paymentKey,
+        String orderId,
+        Long totalAmount,
+        String status,
+        String approvedAt
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossErrorResponse.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/application/dto/TossErrorResponse.java
@@ -1,0 +1,10 @@
+package kr.co.isajjim.infra.toss.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/src/main/java/kr/co/isajjim/infra/toss/domain/service/TossPaymentClient.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/domain/service/TossPaymentClient.java
@@ -1,0 +1,64 @@
+package kr.co.isajjim.infra.toss.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.isajjim.global.common.ResponseCode;
+import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.infra.toss.application.dto.TossConfirmRequest;
+import kr.co.isajjim.infra.toss.application.dto.TossConfirmResponse;
+import kr.co.isajjim.infra.toss.application.dto.TossErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossPaymentClient {
+
+    @Value("${infra.toss.base-url}")
+    private String baseUrl;
+
+    @Value("${infra.toss.secret-key}")
+    private String secretKey;
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public TossConfirmResponse confirm(String paymentKey, String orderId, Long amount) {
+        TossConfirmRequest request = new TossConfirmRequest(paymentKey, orderId, amount);
+
+        return restClient.post()
+                .uri(baseUrl + "/v1/payments/confirm")
+                .header(HttpHeaders.AUTHORIZATION, basicAuthHeader())
+                .body(request)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, response) -> {
+                    String rawBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                    logTossError(response.getStatusCode(), rawBody);
+                    throw new BaseException(ResponseCode.TOSS_PAYMENT_CONFIRM_FAILED);
+                })
+                .body(TossConfirmResponse.class);
+    }
+
+    private String basicAuthHeader() {
+        String credentials = secretKey + ":";
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Toss의 4xx 원문은 클라이언트에 그대로 노출하지 않고 서버 로그에만 남긴다.
+    private void logTossError(HttpStatusCode status, String rawBody) {
+        try {
+            TossErrorResponse error = objectMapper.readValue(rawBody, TossErrorResponse.class);
+            log.error("Toss 결제 승인 실패. status={}, code={}, message={}", status, error.code(), error.message());
+        } catch (Exception e) {
+            log.error("Toss 결제 승인 실패. status={}, body={}", status, rawBody);
+        }
+    }
+}

--- a/src/main/java/kr/co/isajjim/infra/toss/domain/service/TossPaymentClient.java
+++ b/src/main/java/kr/co/isajjim/infra/toss/domain/service/TossPaymentClient.java
@@ -3,6 +3,7 @@ package kr.co.isajjim.infra.toss.domain.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.isajjim.global.common.ResponseCode;
 import kr.co.isajjim.global.exception.BaseException;
+import kr.co.isajjim.infra.toss.application.dto.TossCancelRequest;
 import kr.co.isajjim.infra.toss.application.dto.TossConfirmRequest;
 import kr.co.isajjim.infra.toss.application.dto.TossConfirmResponse;
 import kr.co.isajjim.infra.toss.application.dto.TossErrorResponse;
@@ -45,6 +46,22 @@ public class TossPaymentClient {
                     throw new BaseException(ResponseCode.TOSS_PAYMENT_CONFIRM_FAILED);
                 })
                 .body(TossConfirmResponse.class);
+    }
+
+    public void cancel(String paymentKey, String cancelReason) {
+        TossCancelRequest request = new TossCancelRequest(cancelReason);
+
+        restClient.post()
+                .uri(baseUrl + "/v1/payments/" + paymentKey + "/cancel")
+                .header(HttpHeaders.AUTHORIZATION, basicAuthHeader())
+                .body(request)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, response) -> {
+                    String rawBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                    logTossError(response.getStatusCode(), rawBody);
+                    throw new BaseException(ResponseCode.TOSS_PAYMENT_CANCEL_FAILED);
+                })
+                .toBodilessEntity();
     }
 
     private String basicAuthHeader() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,13 @@ infra:
       static: ${AWS_REGION}
     s3:
       bucket: ${AWS_S3_BUCKET}
+  toss:
+    client-key: ${TOSS_CLIENT_KEY}
+    secret-key: ${TOSS_SECRET_KEY}
+    base-url: ${TOSS_BASE_URL:https://api.tosspayments.com}
+    success-url: ${TOSS_SUCCESS_URL}
+    fail-url: ${TOSS_FAIL_URL}
+    krw-per-credit: ${TOSS_KRW_PER_CREDIT:1}
 
 oauth2:
   allowed-redirect-uris:

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -431,7 +431,7 @@
                 nextBtnId: 'companyNextBtn',
                 emptyMessage: '등록된 파트너가 없습니다.',
                 colspan: 7,
-                state: { page: 0, totalPages: 0, expandedId: null, lastList: [] }
+                state: { page: 0, totalPages: 0, expandedId: null, lastList: [], creditCache: {} }
             },
             users: {
                 endpoint: '/api/v1/admin/users',
@@ -687,11 +687,31 @@
                                 : '-'}</div>
                             ${p.approvalStatus === 'REJECTED' ? `<div>반려 사유: ${escapeHtml(p.rejectionReason || '-')}</div>` : ''}
                             <div>유저 ID: ${p.userId}</div>
+                            ${viewKey === 'companies' ? renderCreditSection(cfg.state.creditCache[p.id]) : ''}
                         </td>
                     `;
                     tbody.appendChild(detailRow);
                 }
             });
+        }
+
+        function renderCreditSection(cache) {
+            if (!cache) {
+                return `<div style="margin-top:10px; padding-top:10px; border-top:1px dashed var(--border);">크레딧 정보 불러오는 중...</div>`;
+            }
+            if (cache.error) {
+                return `<div style="margin-top:10px; padding-top:10px; border-top:1px dashed var(--border); color:var(--danger);">${escapeHtml(cache.error)}</div>`;
+            }
+            const txHtml = cache.transactions.length
+                ? cache.transactions.map(t => `<div>${formatDate(t.createdDate)} · ${t.type === 'CHARGE' ? '충전 +' : '소모 -'}${t.creditAmount.toLocaleString()} (잔액 ${t.balanceAfter.toLocaleString()})</div>`).join('')
+                : '<div>거래 내역이 없습니다.</div>';
+            return `
+                <div style="margin-top:10px; padding-top:10px; border-top:1px dashed var(--border);">
+                    <div style="font-weight:700; margin-bottom:4px;">크레딧 잔액: ${cache.balance.toLocaleString()}</div>
+                    <div style="color:var(--text-faint); font-size:11px; margin-bottom:4px;">최근 거래 내역 (최대 5건)</div>
+                    ${txHtml}
+                </div>
+            `;
         }
 
         function renderUserTable(list) {
@@ -805,10 +825,36 @@
             }
         }
 
-        function toggleDetail(viewKey, id) {
+        async function toggleDetail(viewKey, id) {
             const cfg = VIEWS[viewKey];
-            cfg.state.expandedId = cfg.state.expandedId === id ? null : id;
+            const wasExpanded = cfg.state.expandedId === id;
+            cfg.state.expandedId = wasExpanded ? null : id;
             renderTable(viewKey, cfg.state.lastList);
+
+            if (viewKey === 'companies' && !wasExpanded && !cfg.state.creditCache[id]) {
+                const partner = cfg.state.lastList.find(p => p.id === id);
+                if (!partner) return;
+
+                const [balanceRes, txRes] = await Promise.all([
+                    apiFetch(`/api/v1/admin/partners/${partner.userId}/credits/balance`),
+                    apiFetch(`/api/v1/admin/partners/${partner.userId}/credits/transactions?page=0&size=5&sort=createdDate,desc`)
+                ]);
+
+                if (balanceRes.status === 401 || txRes.status === 401) {
+                    clearToken();
+                    render();
+                    showLoginBanner('로그인이 만료되었습니다. 다시 로그인해주세요.');
+                    return;
+                }
+
+                cfg.state.creditCache[id] = (balanceRes.ok && txRes.ok)
+                    ? { balance: balanceRes.body.data.balance, transactions: txRes.body.data.content }
+                    : { error: `크레딧 정보 조회 실패: ${balanceRes.body?.message || txRes.body?.message || ''}` };
+
+                if (cfg.state.expandedId === id) {
+                    renderTable(viewKey, cfg.state.lastList);
+                }
+            }
         }
 
         async function decide(id, approvalStatus) {

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -181,6 +181,8 @@
                 <button class="nav-item" id="navCompanies" onclick="switchView('companies')">파트너 관리</button>
                 <button class="nav-item" id="navUsers" onclick="switchView('users')">유저 관리</button>
                 <button class="nav-item" id="navEstimates" onclick="switchView('estimates')">견적서 관리</button>
+                <button class="nav-item" id="navCreditBalances" onclick="switchView('creditBalances')">크레딧 잔액 현황</button>
+                <button class="nav-item" id="navCreditTransactions" onclick="switchView('creditTransactions')">크레딧 거래내역</button>
                 <div class="sidebar-footer">
                     <button class="btn-logout" onclick="logout()">로그아웃</button>
                 </div>
@@ -387,6 +389,88 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- Credit Balances Panel -->
+                <div id="creditBalancesPanel" class="hidden">
+                    <div class="filters">
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="creditBalanceSizeFilter" onchange="onFilterChange('creditBalances')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label>검색 (업체명/대표자명)</label>
+                            <input type="text" id="creditBalanceKeywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('creditBalances')">
+                        </div>
+                        <div id="creditBalanceLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>유저ID</th>
+                                <th>업체명</th>
+                                <th>대표자</th>
+                                <th>현재 잔액</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="creditBalanceTableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="creditBalancePageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="creditBalancePrevBtn" onclick="changePage('creditBalances', -1)">이전</button>
+                            <button class="btn-page" id="creditBalanceNextBtn" onclick="changePage('creditBalances', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Credit Transactions Panel -->
+                <div id="creditTransactionsPanel" class="hidden">
+                    <div class="filters">
+                        <div>
+                            <label>페이지 크기</label>
+                            <select id="creditTxSizeFilter" onchange="onFilterChange('creditTransactions')">
+                                <option value="10">10</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label>검색 (업체명/대표자명)</label>
+                            <input type="text" id="creditTxKeywordFilter" placeholder="검색어 입력" oninput="onKeywordInput('creditTransactions')">
+                        </div>
+                        <div id="creditTxLoadingIndicator" class="loading-indicator hidden"><span class="spinner"></span>불러오는 중...</div>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>일시</th>
+                                <th>파트너</th>
+                                <th>유형</th>
+                                <th>크레딧</th>
+                                <th>잔액</th>
+                                <th>참조</th>
+                                <th>액션</th>
+                            </tr>
+                        </thead>
+                        <tbody id="creditTxTableBody"></tbody>
+                    </table>
+
+                    <div class="pagination">
+                        <div id="creditTxPageInfo">—</div>
+                        <div class="controls">
+                            <button class="btn-page" id="creditTxPrevBtn" onclick="changePage('creditTransactions', -1)">이전</button>
+                            <button class="btn-page" id="creditTxNextBtn" onclick="changePage('creditTransactions', 1)">다음</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -399,6 +483,7 @@
         const USER_STATUS_LABEL = { PENDING: '이용약관 미동의', ACTIVE: '활성' };
         const SOCIAL_LABEL = { KAKAO: '카카오', NAVER: '네이버', GOOGLE: '구글' };
         const AI_STATUS_LABEL = { PENDING: '대기', PROCESSING: '분석중', COMPLETED: '완료', FAILED: '실패' };
+        const TX_TYPE_LABEL = { CHARGE: '충전', CONSUME: '소모', REFUND: '환불' };
 
         const VIEWS = {
             applications: {
@@ -464,6 +549,38 @@
                 emptyMessage: '견적서가 없습니다.',
                 colspan: 6,
                 state: { page: 0, totalPages: 0, expandedId: null, lastList: [], detailCache: {} }
+            },
+            creditBalances: {
+                endpoint: '/api/v1/admin/credits/balances',
+                filterParamName: null,
+                filterId: null,
+                fixedValue: null,
+                keywordFilterId: 'creditBalanceKeywordFilter',
+                sizeFilterId: 'creditBalanceSizeFilter',
+                loadingId: 'creditBalanceLoadingIndicator',
+                tableBodyId: 'creditBalanceTableBody',
+                pageInfoId: 'creditBalancePageInfo',
+                prevBtnId: 'creditBalancePrevBtn',
+                nextBtnId: 'creditBalanceNextBtn',
+                emptyMessage: '등록된 파트너가 없습니다.',
+                colspan: 5,
+                state: { page: 0, totalPages: 0, lastList: [] }
+            },
+            creditTransactions: {
+                endpoint: '/api/v1/admin/credits/transactions',
+                filterParamName: null,
+                filterId: null,
+                fixedValue: null,
+                keywordFilterId: 'creditTxKeywordFilter',
+                sizeFilterId: 'creditTxSizeFilter',
+                loadingId: 'creditTxLoadingIndicator',
+                tableBodyId: 'creditTxTableBody',
+                pageInfoId: 'creditTxPageInfo',
+                prevBtnId: 'creditTxPrevBtn',
+                nextBtnId: 'creditTxNextBtn',
+                emptyMessage: '거래 내역이 없습니다.',
+                colspan: 7,
+                state: { page: 0, totalPages: 0, lastList: [] }
             }
         };
         let currentView = 'applications';
@@ -531,10 +648,14 @@
             document.getElementById('navCompanies').classList.toggle('active', viewKey === 'companies');
             document.getElementById('navUsers').classList.toggle('active', viewKey === 'users');
             document.getElementById('navEstimates').classList.toggle('active', viewKey === 'estimates');
+            document.getElementById('navCreditBalances').classList.toggle('active', viewKey === 'creditBalances');
+            document.getElementById('navCreditTransactions').classList.toggle('active', viewKey === 'creditTransactions');
             document.getElementById('applicationsPanel').classList.toggle('hidden', viewKey !== 'applications');
             document.getElementById('companiesPanel').classList.toggle('hidden', viewKey !== 'companies');
             document.getElementById('usersPanel').classList.toggle('hidden', viewKey !== 'users');
             document.getElementById('estimatesPanel').classList.toggle('hidden', viewKey !== 'estimates');
+            document.getElementById('creditBalancesPanel').classList.toggle('hidden', viewKey !== 'creditBalances');
+            document.getElementById('creditTransactionsPanel').classList.toggle('hidden', viewKey !== 'creditTransactions');
             document.getElementById('forbiddenBanner').classList.add('hidden');
             document.getElementById('errorBanner').classList.add('hidden');
             loadView(viewKey);
@@ -640,6 +761,14 @@
             }
             if (viewKey === 'estimates') {
                 renderEstimateTable(list);
+                return;
+            }
+            if (viewKey === 'creditBalances') {
+                renderCreditBalanceTable(list);
+                return;
+            }
+            if (viewKey === 'creditTransactions') {
+                renderCreditTransactionTable(list);
                 return;
             }
 
@@ -803,6 +932,87 @@
                 <div>견적 항목: ${itemsHtml}</div>
                 <div>이미지: ${imagesHtml}</div>
             `;
+        }
+
+        function renderCreditBalanceTable(list) {
+            const cfg = VIEWS.creditBalances;
+            const tbody = document.getElementById(cfg.tableBodyId);
+            tbody.innerHTML = '';
+            if (!list.length) {
+                tbody.innerHTML = `<tr class="empty-row"><td colspan="${cfg.colspan}">${cfg.emptyMessage}</td></tr>`;
+                return;
+            }
+            list.forEach(b => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${b.userId}</td>
+                    <td>${escapeHtml(b.companyName)}</td>
+                    <td>${escapeHtml(b.representativeName)}</td>
+                    <td>${b.balance.toLocaleString()}</td>
+                    <td class="actions">
+                        <button class="btn-detail">거래내역 보기</button>
+                    </td>
+                `;
+                row.querySelector('button').addEventListener('click', () => viewCreditTransactions(b.companyName));
+                tbody.appendChild(row);
+            });
+        }
+
+        function renderCreditTransactionTable(list) {
+            const cfg = VIEWS.creditTransactions;
+            const tbody = document.getElementById(cfg.tableBodyId);
+            tbody.innerHTML = '';
+            if (!list.length) {
+                tbody.innerHTML = `<tr class="empty-row"><td colspan="${cfg.colspan}">${cfg.emptyMessage}</td></tr>`;
+                return;
+            }
+            list.forEach(t => {
+                const row = document.createElement('tr');
+                const sign = t.type === 'CHARGE' ? '+' : '-';
+                const amountColor = t.type === 'CHARGE' ? 'var(--success)' : 'var(--danger)';
+                const canRefund = t.type === 'CHARGE' && t.referenceId != null;
+                row.innerHTML = `
+                    <td>${formatDate(t.createdDate)}</td>
+                    <td>${escapeHtml(t.userName)} (${escapeHtml(t.userEmail)})</td>
+                    <td>${TX_TYPE_LABEL[t.type] || t.type}</td>
+                    <td style="color:${amountColor};">${sign}${t.creditAmount.toLocaleString()}</td>
+                    <td>${t.balanceAfter.toLocaleString()}</td>
+                    <td>${escapeHtml(t.referenceType || '-')}</td>
+                    <td class="actions">
+                        ${canRefund ? `<button class="btn-delete" onclick="refundCharge(${t.referenceId})">환불</button>` : '-'}
+                    </td>
+                `;
+                tbody.appendChild(row);
+            });
+        }
+
+        // 잔액 현황 탭에서 특정 업체의 거래내역 탭으로 이동 (검색어를 업체명으로 채워서 필터링)
+        function viewCreditTransactions(companyName) {
+            document.getElementById('creditTxKeywordFilter').value = companyName;
+            VIEWS.creditTransactions.state.page = 0;
+            switchView('creditTransactions');
+        }
+
+        async function refundCharge(chargeOrderId) {
+            const reason = prompt('환불(결제취소) 사유를 입력하세요.');
+            if (reason === null) return;
+            if (!reason.trim()) { alert('환불 사유를 입력해야 합니다.'); return; }
+            if (!confirm('이 충전 건을 환불하시겠습니까? TossPayments 결제가 실제로 취소되며 되돌릴 수 없습니다.')) return;
+
+            const { ok, status, body } = await apiFetch(`/api/v1/admin/credits/charges/${chargeOrderId}/refund`, {
+                method: 'POST',
+                body: JSON.stringify({ reason: reason.trim() })
+            });
+            if (status === 401) {
+                clearToken();
+                render();
+                showLoginBanner('로그인이 만료되었습니다. 다시 로그인해주세요.');
+                return;
+            }
+            if (status === 403) { document.getElementById('forbiddenBanner').classList.remove('hidden'); return; }
+            if (!ok) { alert(`환불 실패: ${body?.message || status}`); return; }
+            alert('환불이 완료되었습니다.');
+            loadView('creditTransactions');
         }
 
         async function toggleEstimateDetail(id) {


### PR DESCRIPTION
## 🚀 개요

- 파트너(이사업체)가 TossPayments로 크레딧을 충전하고, 향후 "견적서 발송" 기능에서 크레딧을 소모할 수 있도록 충전/잔액/거래 내역 관리 로직을 신규 구현합니다.
- 관리자가 CS/분쟁 대응 목적으로 파트너 잔액·거래내역을 전체 조회하고, 잘못 충전된 건을 Toss 결제취소(환불)로 되돌릴 수 있는 기능도 함께 구현합니다.
- "견적서 발송" 자체(파트너-견적서 매칭)는 아직 존재하지 않아 이번 PR 범위에서 제외했고, 소모(consume) 로직은 이후 해당 기능에서 바로 호출할 수 있는 형태로 준비해두었습니다.


## ✨ 작업 내용

- `domains/credit` 신규 도메인 추가
    - `CreditChargeOrder`(READY/DONE/FAILED/REFUNDED) / `CreditBalance` / `CreditTransaction`(CHARGE/CONSUME/REFUND) 엔티티 및 리포지토리 (잔액·주문 갱신에 비관적 락 적용)
    - `CreditChargeOrderService` / `CreditLedgerService` — 충전 주문 생명주기, 잔액 증감, 원장(ledger) 기록, 환불 시 잔액 차감(`refund`)
    - `CreditUseCase` — 파트너용 `POST /api/v1/partner-credits/charges/ready`, `POST /charges/confirm`, `GET /balance`, `GET /transactions`
    - `AdminCreditUseCase` — CS/분쟁 대응용 `GET /api/v1/admin/partners/{userId}/credits/{balance,transactions}`
    - `AdminCreditOverviewApi` / `AdminCreditOverviewController`
        - `GET /api/v1/admin/credits/balances` — 승인된 파트너 전체의 잔액 현황 (업체명/대표자명 검색)
        - `GET /api/v1/admin/credits/transactions` — 전체 파트너의 충전/소모/환불 거래내역 (업체명/대표자명 검색)
        - `POST /api/v1/admin/credits/charges/{chargeOrderId}/refund` — 충전 건 환불(전액만 지원)
- `infra/toss` 신규 추가
    - `TossPaymentClient.confirm(...)` — 결제 승인(confirm) API 연동
    - `TossPaymentClient.cancel(...)` — 결제취소(환불) API 연동
- `global/common/ResponseCode.java` — `CREDIT-001` ~ `CREDIT-008` 에러 코드 추가
- `application.yml`, `.env.example` — `infra.toss.*` 설정(client-key, secret-key, base-url, success/fail-url, krw-per-credit) 추가, 기본 환산 비율은 1원 = 1크레딧
- 어드민 페이지(`static/admin/index.html`)에 "크레딧 잔액 현황" / "크레딧 거래내역" 탭 구현, 거래내역의 충전(CHARGE) 건에 환불 가능


## 🔧 앞으로의 과제

- "견적서 발송" 기능 구현 시 `CreditLedgerService.consume(userId, creditAmount, referenceType, referenceId)`를 호출하도록 연동
- 동시성(잔액 이중 차감 방지), 금액 변조 방어, 이중 confirm 방지, 환불 관련(이중 환불 방지, 잔액 부족 시 환불 거부) 자동화 테스트 작성
- Toss 샌드박스 키로 실결제 플로우(ready → 위젯 결제 → confirm) 및 환불(취소) 플로우 수동 검증
- `READY` 상태로 남아 미완료된 충전 주문을 정리하는 배치/만료 로직 (현재는 범위 밖)
- 환불 처리 시 어느 관리자 계정이 처리했는지는 별도로 기록하지 않음 — 필요 시 감사 로그(actor) 추가 고려
- Toss 웹훅 수신 엔드포인트 없음 — 프론트가 confirm을 호출하지 못하는 네트워크 장애 상황에서는 주문이 READY로 남을 수 있음 (Toss 결제는 실제로 완료됐는데 우리 시스템은 모르는 갭)
- 어드민 거래내역 화면에서 이미 환불된 충전 건도 "환불" 버튼이 계속 노출됨 — 클릭하면 서버가 `CREDIT-008`로 막아주므로 안전하지만, 버튼을 비활성화하려면 거래내역 응답에 해당 충전 건의 현재 상태(REFUNDED 여부)를 추가로 내려줘야 함 (페이지네이션 경계 때문에 클라이언트 단독 판단은 부정확할 수 있음)


## 💡 기술적 사항

- 충전은 2단계(ready/confirm) 플로우로 처리합니다. `orderId`와 `amount`는 서버가 `ready` 시점에 생성/기록하고, `confirm` 요청의 `amount`가 이와 다르면 Toss 승인 API를 호출하기 전에 즉시 거부해 클라이언트 측 금액 조작을 막습니다.
- `confirmCharge`는 클래스 레벨 `@Transactional(readOnly = true)` 컨벤션을 따르지 않고 `Propagation.NOT_SUPPORTED`로 재정의했습니다. Toss 승인 API 호출(최대 `rest-client.read-timeout`=30초) 동안 잔액/주문 행 락을 들고 있지 않기 위함이며, 실제 DB 반영(주문 완료 + 잔액 증가 + 원장 기록)은 `CreditChargeOrderService.completeAndCredit(...)` 하나의 트랜잭션으로 원자적으로 처리해 "주문은 완료됐는데 잔액은 반영 안 됨" 같은 정합성 문제를 방지했습니다.
- **환불(`refundCharge`)도 동일한 설계를 따릅니다.** Toss 결제취소 API 호출은 트랜잭션 밖에서 실행하고, 성공 후 `CreditChargeOrderService.refundAndDeduct(...)`에서 주문을 잠금 재조회해 `DONE` 상태인지 재확인한 뒤 `REFUNDED`로 전환 + 잔액 차감 + 원장(REFUND) 기록을 한 트랜잭션으로 묶습니다. 전액 환불만 지원하며, `DONE`이 아니거나 이미 `REFUNDED`인 건은 `CREDIT-008`(409)로 차단합니다.
- 잔액 갱신은 낙관적 락(`@Version`) 대신 비관적 락(`@Lock(PESSIMISTIC_WRITE)`)을 사용했습니다. 크레딧 소모/환불 시 "0 미만 금지" 불변식을 재시도 루프 없이 원자적으로 보장하기 위함이며, 파트너별 크레딧 조작은 QPS가 낮을 것으로 예상되어 락 경합 위험은 낮다고 판단했습니다.
- 크레딧 잔액/원장은 `PartnerProfile`이 아닌 `UserEntity`/`userId`에 직접 연결했습니다. `role=PARTNER`는 이미 관리자 승인 후에만 부여되므로 `@PreAuthorize("hasRole('PARTNER')")`로 충분히 승인된 파트너만 접근 가능함이 보장됩니다.